### PR TITLE
feat(repair): prune unresolvable trust danglers + surface dangling-count

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,7 @@ interface ParsedArgs {
   acpManager?: string;
   acpToAgent?: string;
   force: boolean;
+  apply: boolean;
 }
 
 function main(): void {
@@ -239,6 +240,17 @@ function main(): void {
         : undefined;
       console.log(JSON.stringify({ report, result }, null, 2));
       process.exitCode = result && !result.accepted ? 1 : 0;
+      return;
+    }
+
+    if (command === "repair") {
+      if (args.apply) {
+        const pruned = store.pruneUnresolvableTrustEdges();
+        console.log(JSON.stringify({ dryRun: false, count: pruned.deleted, relations: pruned.relations }, null, 2));
+      } else {
+        const relations = store.unresolvableTrustEdges();
+        console.log(JSON.stringify({ dryRun: true, count: relations.length, relations }, null, 2));
+      }
       return;
     }
 
@@ -579,6 +591,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let acpManager: string | undefined;
   let acpToAgent: string | undefined;
   let force = false;
+  let apply = false;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -665,6 +678,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       acpToAgent = requireValue(argv, ++index, "--acp-to-agent");
     } else if (arg === "--force") {
       force = true;
+    } else if (arg === "--apply") {
+      apply = true;
     } else {
       command.push(arg);
     }
@@ -723,7 +738,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     acpStatus,
     acpManager,
     acpToAgent,
-    force
+    force,
+    apply
   };
 }
 
@@ -914,6 +930,7 @@ Commands:
   recall trust [--db path]
   recall calibration [--db path]                                   per-actor stated-confidence vs contradiction outcomes
   recall maintenance [--derive] [--db path]
+  recall repair [--apply] [--db path]                              prune dangling/unresolvable trust edges (dry-run default; --apply deletes)
   recall tick [--derive] [--db path]
   recall page [index|reflections|agent-profile|user-profile|team-metrics|witnesses|workbench|handoffs|objectives|acp-queue|acp-manager] [--project Recall] [--topic memory] [--identity agent:codex] [--limit 25]
   recall cell show <cell-id-or-address> [--db path]

--- a/src/core/analysis.ts
+++ b/src/core/analysis.ts
@@ -41,6 +41,19 @@ export interface ContradictionFinding {
   relation: "contradicts" | "concerns";
 }
 
+export interface DanglingEvidenceFinding {
+  relationId: string;
+  kind: string;
+  sourceId: string;
+  targetId: string;
+}
+
+export interface DanglingEvidenceReport {
+  total: number;
+  byKind: Record<string, number>;
+  worst: DanglingEvidenceFinding[];
+}
+
 export interface ProvenanceHealth {
   totalWitnesses: number;
   byOrigin: Record<string, number>;
@@ -75,6 +88,7 @@ export interface MemoryHealthReport {
   beliefs: BeliefPressure[];
   stale: StaleMemoryFinding[];
   contradictions: ContradictionFinding[];
+  danglingEvidence: DanglingEvidenceReport;
   calibration: ActorCalibration[];
   criticalWarnings: CriticalWarning[];
   curiosityTargets: CuriosityTarget[];
@@ -94,6 +108,7 @@ export function analyzeMemory(store: RecallStore, now = new Date()): MemoryHealt
     .sort((a, b) => b.severity - a.severity);
   const contradictions = contradictionFindings(nodes, byId)
     .sort((a, b) => b.severity - a.severity);
+  const danglingEvidence = buildDanglingEvidence(store.unresolvableTrustEdges?.() ?? []);
 
   return {
     createdAt: now.toISOString(),
@@ -102,11 +117,32 @@ export function analyzeMemory(store: RecallStore, now = new Date()): MemoryHealt
     beliefs,
     stale,
     contradictions,
+    danglingEvidence,
     calibration: calibrationFromNodes(nodes),
     criticalWarnings: criticalWarnings(provenance, beliefs, stale, contradictions),
     curiosityTargets: curiosityTargets(provenance, beliefs, stale, contradictions),
-    nextActions: nextActions(provenance, beliefs, stale, contradictions)
+    nextActions: nextActions(provenance, beliefs, stale, contradictions, danglingEvidence)
   };
+}
+
+// Trust edges whose target resolves to no node — inert pollution that never
+// feeds effective confidence but skews the eval and aggregate surface. The
+// count + worst offenders surface in the health report so drift is visible
+// (`recall repair --apply` prunes them).
+function buildDanglingEvidence(
+  relations: { id: string; kind: string; sourceId: string; targetId: string }[]
+): DanglingEvidenceReport {
+  const byKind: Record<string, number> = {};
+  for (const relation of relations) {
+    byKind[relation.kind] = (byKind[relation.kind] ?? 0) + 1;
+  }
+  const worst = relations.slice(0, 10).map((relation) => ({
+    relationId: relation.id,
+    kind: relation.kind,
+    sourceId: relation.sourceId,
+    targetId: relation.targetId
+  }));
+  return { total: relations.length, byKind: sortRecord(byKind), worst };
 }
 
 export function memoryHealthToProposal(
@@ -486,7 +522,8 @@ function nextActions(
   provenance: ProvenanceHealth,
   beliefs: BeliefPressure[],
   stale: StaleMemoryFinding[],
-  contradictions: ContradictionFinding[]
+  contradictions: ContradictionFinding[],
+  danglingEvidence: DanglingEvidenceReport
 ): string[] {
   const actions: string[] = [];
   if (provenance.unknownOriginRatio > 0.2) {
@@ -501,6 +538,9 @@ function nextActions(
   const pressured = beliefs.find((belief) => belief.recommendation !== "trust");
   if (pressured) {
     actions.push(`Reassess belief "${pressured.title}" because recommendation is ${pressured.recommendation}.`);
+  }
+  if (danglingEvidence.total > 0) {
+    actions.push(`Prune ${danglingEvidence.total} dangling/unresolvable trust edge(s) with \`recall repair --apply\` (deletes them; run \`recall repair\` first to preview).`);
   }
   if (actions.length === 0) {
     actions.push("No urgent belief, stale-memory, or contradiction pressure detected.");

--- a/src/core/evals.ts
+++ b/src/core/evals.ts
@@ -2,6 +2,7 @@ import { compileContext } from "./context-compiler.js";
 import { calibrationFactors, effectiveConfidence } from "./evidence.js";
 import { cellReferenceTarget } from "./references.js";
 import type { RecallStore, SubgraphFilter } from "./store.js";
+import { TRUST_RELATION_KINDS } from "./types.js";
 
 // Model-free structural self-audits of the substrate's own guarantees. Each is
 // deterministic and read-only, so `recall eval run` audits the floor with no
@@ -194,7 +195,7 @@ const INVARIANTS: Record<RecallEvalInvariant, (store: RecallStore) => InvariantR
   // depends_on is lineage/provenance and may legitimately reference a cell that
   // was rolled back or never re-derived, so it is deliberately excluded.
   "relation-targets-resolve": (store) => {
-    const TRUST = new Set(["supports", "contradicts", "concerns"]);
+    const TRUST = new Set<string>(TRUST_RELATION_KINDS);
     const relations = store.listRelations(undefined, "both", 2000).filter((r) => TRUST.has(r.kind));
     let dangling = 0;
     const danglingTargets: string[] = [];

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -14,7 +14,8 @@ import {
 } from "./derivation.js";
 import { runRecallEval, type RecallEvalResult, type RecallEvalSuite } from "./evals.js";
 import { executeHyperedgeProgram, validateProgramSpec } from "./programs.js";
-import { resolveCellReference, type ResolvedCellReference } from "./references.js";
+import { cellReferenceTarget, resolveCellReference, type ResolvedCellReference } from "./references.js";
+import { TRUST_RELATION_KINDS } from "./types.js";
 import { calibrationFactors, effectiveConfidence } from "./evidence.js";
 import { buildFtsMatchQuery, fuseCandidates, searchTerms, type FuseOptions, type LexicalCandidate, type SearchHit } from "./retrieval.js";
 import { cosine, embedTextRecord, hashEmbedding, textForEmbedding, type SemanticHit } from "./semantic.js";
@@ -145,6 +146,8 @@ export interface RecallStore {
   getNodeByAddress(address: string): RecallNode | null;
   getNodeByPrefix(prefix: string): RecallNode | null;
   listRelations(nodeId?: string, direction?: "in" | "out" | "both", limit?: number): RecallRelation[];
+  unresolvableTrustEdges?(): RecallRelation[];
+  pruneUnresolvableTrustEdges?(): { deleted: number; relations: RecallRelation[] };
   listNodes(limit?: number): RecallNode[];
   listRollback(limit?: number): RollbackEntry[];
   applyRollback(id: string, apply?: boolean): { id: string; applied: boolean; actions: string[] };
@@ -604,6 +607,59 @@ export class SQLiteRecallStore implements RecallStore {
       )
       .all(...params) as unknown as RelationRow[];
     return rows.map(rowToRelation);
+  }
+
+  // Trust-bearing edges (supports/contradicts/concerns) whose source or target
+  // resolves to no node — inert pollution that never feeds effective confidence
+  // (the read skips them) but pollutes the eval surface and the aggregate.
+  // Admission now refuses to materialize such an edge, so any present are legacy
+  // edges from older binaries. Three deliberate choices:
+  //   - getNode is status-agnostic on purpose: an ARCHIVED target row still
+  //     exists (rollback archives, never deletes the row), so its edge is
+  //     restorable and is NOT a dangler — only a genuinely-absent target is.
+  //     This matches the relation-targets-resolve eval exactly, so the audit and
+  //     the prune can never disagree on what "dangling" means.
+  //   - depends_on is excluded — it is lineage and may legitimately dangle
+  //     (rolled-back derivations, external anchors); it is never scored.
+  //   - intentionally unbounded (the eval samples 2000) so repair cleans ALL
+  //     legacy danglers regardless of graph size.
+  private trustDanglers(): RecallRelation[] {
+    const placeholders = TRUST_RELATION_KINDS.map(() => "?").join(", ");
+    const rows = this.db
+      .prepare(`SELECT * FROM graph_relations WHERE kind IN (${placeholders})`)
+      .all(...TRUST_RELATION_KINDS) as unknown as RelationRow[];
+    const danglers: RecallRelation[] = [];
+    for (const row of rows) {
+      const relation = rowToRelation(row);
+      const target = cellReferenceTarget(relation.targetId);
+      if (!this.getNode(relation.sourceId) || !this.getNode(target)) {
+        danglers.push(relation);
+      }
+    }
+    return danglers;
+  }
+
+  unresolvableTrustEdges(): RecallRelation[] {
+    return this.trustDanglers();
+  }
+
+  pruneUnresolvableTrustEdges(): { deleted: number; relations: RecallRelation[] } {
+    // BEGIN IMMEDIATE takes the write lock up front and the scan runs INSIDE the
+    // transaction, so the set we delete is exactly the set we found — no
+    // concurrent writer can resolve or remove an edge between scan and delete.
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const danglers = this.trustDanglers();
+      const del = this.db.prepare("DELETE FROM graph_relations WHERE id = ?");
+      for (const relation of danglers) {
+        del.run(relation.id);
+      }
+      this.db.exec("COMMIT");
+      return { deleted: danglers.length, relations: danglers };
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
   }
 
   listNodes(limit = 20): RecallNode[] {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -58,6 +58,11 @@ export const RELATION_KINDS = [
 export type NodeKind = (typeof NODE_KINDS)[number];
 export type RelationKind = (typeof RELATION_KINDS)[number];
 
+// Trust-bearing relations whose source/target resolution feeds effective
+// confidence. Shared so admission's drop-on-write, the relation-targets-resolve
+// eval, and the repair pruner all agree on exactly which edges are "trust" edges.
+export const TRUST_RELATION_KINDS = ["supports", "contradicts", "concerns"] as const;
+
 export type ActorKind = "llm" | "human" | "daemon" | "connector" | "program";
 export type IntentKind =
   | "observation"

--- a/tests/relation-repair.test.ts
+++ b/tests/relation-repair.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import { describe, it } from "node:test";
+import { admitWriteProposal } from "../src/core/admission.js";
+import { analyzeMemory } from "../src/core/analysis.js";
+import { SQLiteRecallStore } from "../src/core/store.js";
+import { makeProposal, tempDbPath } from "./helpers.js";
+
+// The historical danglers (240 in the dogfood graph as of 2026-06) entered the
+// graph BEFORE admission learned to drop unresolved trust edges — written by
+// older binaries. Admission now refuses to materialize such an edge, so the
+// ONLY way to reproduce that legacy state is to insert a raw trust relation
+// whose target node does not exist, bypassing admission entirely.
+function injectDangling(dbPath: string, kind: string, sourceId: string, targetId: string): string {
+  const db = new DatabaseSync(dbPath);
+  const id = randomUUID();
+  try {
+    db.prepare(
+      "INSERT INTO graph_relations (id, kind, source_id, target_id, data_json, created_at) VALUES (?, ?, ?, ?, '{}', ?)"
+    ).run(id, kind, sourceId, targetId, "2026-06-01T00:00:00.000Z");
+  } finally {
+    db.close();
+  }
+  return id;
+}
+
+function seedCell(store: SQLiteRecallStore, title: string): string {
+  const result = admitWriteProposal(
+    makeProposal({ content: { title, body: `${title} body`, summary: title } }),
+    store,
+    { now: new Date("2026-06-01T00:00:00.000Z") }
+  );
+  assert.equal(result.accepted, true);
+  return result.node!.id;
+}
+
+describe("unresolvable trust-edge repair", () => {
+  it("finds a dangling trust edge whose target resolves to no node", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const source = seedCell(store, "Source cell");
+      const relId = injectDangling(temp.path, "contradicts", source, "HIERARCHY_FORCED");
+      const found = store.unresolvableTrustEdges();
+      assert.equal(found.length, 1);
+      assert.equal(found[0]!.id, relId);
+      assert.equal(found[0]!.kind, "contradicts");
+      assert.equal(found[0]!.targetId, "HIERARCHY_FORCED");
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  it("ignores resolvable trust edges and dangling depends_on (lineage is never scored)", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const source = seedCell(store, "Source cell");
+      const target = seedCell(store, "Target cell");
+      admitWriteProposal(
+        makeProposal({ content: { title: "Supporter", body: "supports target", summary: "s" }, evidence: { supports: [target] } }),
+        store,
+        { now: new Date("2026-06-01T00:01:00.000Z") }
+      );
+      injectDangling(temp.path, "depends_on", source, "external-anchor-not-a-cell");
+      assert.equal(store.unresolvableTrustEdges().length, 0);
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  it("prunes only the unresolvable trust edges, leaving resolvable ones intact", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const source = seedCell(store, "Source cell");
+      const target = seedCell(store, "Target cell");
+      admitWriteProposal(
+        makeProposal({ content: { title: "Supporter", body: "supports target", summary: "s" }, evidence: { supports: [target] } }),
+        store,
+        { now: new Date("2026-06-01T00:01:00.000Z") }
+      );
+      injectDangling(temp.path, "contradicts", source, "PHANTOM_ONE");
+      injectDangling(temp.path, "concerns", source, "PHANTOM_TWO");
+
+      const result = store.pruneUnresolvableTrustEdges();
+      assert.equal(result.deleted, 2);
+      assert.equal(store.unresolvableTrustEdges().length, 0);
+      const survivors = store.listRelations(target, "in", 100).filter((r) => r.kind === "supports");
+      assert.equal(survivors.length, 1, "the resolvable supports edge survives the prune");
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  it("is a no-op (deletes nothing) when there are no danglers", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const target = seedCell(store, "Target cell");
+      admitWriteProposal(
+        makeProposal({ content: { title: "Supporter", body: "supports target", summary: "s" }, evidence: { supports: [target] } }),
+        store,
+        { now: new Date("2026-06-01T00:01:00.000Z") }
+      );
+      assert.equal(store.pruneUnresolvableTrustEdges().deleted, 0);
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  it("surfaces a dangling-evidence count, by-kind breakdown, and worst offenders in the health report", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const source = seedCell(store, "Source cell");
+      injectDangling(temp.path, "contradicts", source, "PHANTOM_A");
+      injectDangling(temp.path, "supports", source, "PHANTOM_B");
+
+      const report = analyzeMemory(store);
+      assert.equal(report.danglingEvidence.total, 2);
+      assert.equal(report.danglingEvidence.byKind.contradicts, 1);
+      assert.equal(report.danglingEvidence.byKind.supports, 1);
+      assert.equal(report.danglingEvidence.worst.length, 2);
+      assert.ok(
+        report.nextActions.some((action) => /dangling/i.test(action)),
+        "a next action flags the dangling-evidence load"
+      );
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  it("reports zero dangling evidence on a clean graph", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      seedCell(store, "Lonely cell");
+      const report = analyzeMemory(store);
+      assert.equal(report.danglingEvidence.total, 0);
+      assert.deepEqual(report.danglingEvidence.worst, []);
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  // Guard: an archived target is NOT a dangler. Rollback archives a node
+  // (status flip) but never deletes the row, so getNode still returns it and
+  // the edge stays restorable. Pruning it would orphan a recoverable relation
+  // AND diverge from the relation-targets-resolve eval, which also uses getNode.
+  it("does NOT prune a trust edge whose target exists but is archived (archived != absent)", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const target = seedCell(store, "Target cell");
+      admitWriteProposal(
+        makeProposal({ content: { title: "Supporter", body: "supports target", summary: "s" }, evidence: { supports: [target] } }),
+        store,
+        { now: new Date("2026-06-01T00:01:00.000Z") }
+      );
+      const db = new DatabaseSync(temp.path);
+      db.prepare("UPDATE graph_nodes SET status = 'archived' WHERE id = ?").run(target);
+      db.close();
+
+      assert.equal(store.unresolvableTrustEdges().length, 0, "edge to an archived-but-present node is not dangling");
+      assert.equal(store.pruneUnresolvableTrustEdges().deleted, 0);
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+});
+
+const CLI = ["--disable-warning=ExperimentalWarning", "dist/src/cli.js"];
+
+describe("cli repair", () => {
+  it("dry-runs by default (reports, deletes nothing) and prunes only with --apply", () => {
+    const temp = tempDbPath();
+    let source: string;
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      source = seedCell(store, "Source cell");
+    } finally {
+      store.close();
+    }
+    injectDangling(temp.path, "contradicts", source, "PHANTOM_CLI");
+    try {
+      const dry = execFileSync(process.execPath, [...CLI, "repair", "--db", temp.path], { encoding: "utf8" });
+      assert.match(dry, /"dryRun": true/);
+      assert.match(dry, /"count": 1/);
+
+      const afterDry = new SQLiteRecallStore(temp.path);
+      assert.equal(afterDry.unresolvableTrustEdges().length, 1, "dry-run must not delete");
+      afterDry.close();
+
+      const applied = execFileSync(process.execPath, [...CLI, "repair", "--apply", "--db", temp.path], { encoding: "utf8" });
+      assert.match(applied, /"dryRun": false/);
+      assert.match(applied, /"count": 1/);
+
+      const afterApply = new SQLiteRecallStore(temp.path);
+      assert.equal(afterApply.unresolvableTrustEdges().length, 0, "--apply deletes the dangler");
+      afterApply.close();
+    } finally {
+      temp.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## What

- **`recall repair`** CLI verb, dry-run by default (`{dryRun, count, relations}`), `--apply` prunes.
- **Store methods** `unresolvableTrustEdges()` / `pruneUnresolvableTrustEdges()`, find/delete trust edges (`supports`/`contradicts`/`concerns`) whose source or target resolves to no node.
- **`analyzeMemory` / `recall beliefs`** now report `danglingEvidence: { total, byKind, worst[] }` + a next-action.

## Why

Trust edges feed effective confidence; an edge to a non-existent node is inert pollution that keeps the `relation-targets-resolve` eval red and skews the aggregate. Admission already drops these on write, and `migrateRelationTargets()` repairs the *recoverable* ones on open. What remained were **unrecoverable legacy danglers** (free-text anchors, no-match prefixes) that pre-date drop-on-write, they can only be pruned, and the count had no home in `recall beliefs`.

## Design notes (from adversarial review)

- Dangling definition matches the `relation-targets-resolve` eval **exactly** via a shared `TRUST_RELATION_KINDS` constant, audit and prune can never diverge.
- Prune scans **inside a `BEGIN IMMEDIATE` transaction**, atomic vs concurrent writers (no TOCTOU).
- `depends_on` excluded (lineage; may legitimately dangle).
- **Archived ≠ absent**: rollback archives a node (status flip) but never deletes the row, so `getNode` still returns it and its edge stays restorable, not pruned. Guard test locks this in.

## Test plan

`tests/relation-repair.test.ts`: finder, pruner, no-op, archived-guard, health-report surfacing, CLI dry-run/apply. **Full suite 148/148, e2e 94/94.**