### PR TITLE
fix(ci): make Python hook tests hermetic (recall shim on PATH)

### DIFF
--- a/python/hooks/test_hooks.py
+++ b/python/hooks/test_hooks.py
@@ -64,7 +64,25 @@ def test_inject_topical() -> bool:
 
 def test_inject_temporal() -> bool:
     print(f"\n{Y}TEST 2{X}: inject-context with temporal query")
-    rc, out, _ = run_hook(INJECT, "what changed since yesterday")
+    # Hermetic: seed a non-empty graph so the hook reaches its routing branches
+    # rather than the cold-start "graph is empty" message (temporal routing only
+    # applies when there is a graph to diff). Without this the test silently
+    # depended on an ambient ~/.recall DB existing, which fails on a clean CI
+    # checkout — the others (TEST 14+) all seed their own DB for the same reason.
+    import tempfile
+    tmp_db = tempfile.mktemp(suffix=".sqlite3", prefix="inject-temporal-")
+    subprocess.run(["recall", "init", "--db", tmp_db], capture_output=True)
+    helper = HOOKS.parent / "scripts" / "recall_helper.py"
+    subprocess.run([
+        "python3", str(helper), "--kind", "observation",
+        "--title", "seed cell so the graph is non-empty",
+        "--body", "seed", "--confidence", "0.6", "--topics", "seed",
+        "--project", "test-temporal", "--admit", "--db", tmp_db,
+    ], capture_output=True, text=True, timeout=15)
+    rc, out, _ = run_hook(INJECT, "what changed since yesterday",
+                          env_overrides={"RECALL_DB": tmp_db})
+    try: os.unlink(tmp_db)
+    except FileNotFoundError: pass
     ok = True
     ok &= check("exits zero", rc == 0)
     ok &= check("detects temporal intent", "temporal" in out.lower() or "diff" in out.lower())

--- a/scripts/run-python-tests.mjs
+++ b/scripts/run-python-tests.mjs
@@ -1,8 +1,47 @@
 import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const candidates = process.platform === "win32" ? ["python", "py"] : ["python3", "python"];
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cli = join(repoRoot, "dist", "src", "cli.js");
+
+// The hooks (and the tests that exercise them) invoke the `recall` binary by
+// name, exactly as a real install puts it on PATH. In CI the package is built
+// but never linked, so a bare `recall` is unresolvable and the suite dies with
+// FileNotFoundError. Rather than depend on a global install, hand the suite a
+// hermetic `recall` shim pointing at this repo's own built CLI, on PATH. This
+// fixes CI and any local contributor who hasn't `npm link`ed recall.
+if (!existsSync(cli)) {
+  const build = spawnSync("npm", ["run", "build"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  if (build.status !== 0) {
+    console.error("Cannot run python tests: build failed, so there is no recall CLI to shim.");
+    process.exit(build.status ?? 1);
+  }
+}
+
+const isWin = process.platform === "win32";
+const node = process.execPath;
+const shimDir = mkdtempSync(join(tmpdir(), "recall-shim-"));
+if (isWin) {
+  // --disable-warning matches the bin shebang so the experimental-sqlite
+  // warning never leaks into stderr that tests assert against.
+  writeFileSync(join(shimDir, "recall.cmd"), `@echo off\r\n"${node}" --disable-warning=ExperimentalWarning "${cli}" %*\r\n`);
+} else {
+  const shim = join(shimDir, "recall");
+  writeFileSync(shim, `#!/usr/bin/env sh\nexec "${node}" --disable-warning=ExperimentalWarning "${cli}" "$@"\n`);
+  chmodSync(shim, 0o755);
+}
+const env = { ...process.env, PATH: `${shimDir}${isWin ? ";" : ":"}${process.env.PATH ?? ""}` };
+
+const candidates = isWin ? ["python", "py"] : ["python3", "python"];
 const python = candidates.find((candidate) => {
-  const result = spawnSync(candidate, ["--version"], { stdio: "ignore" });
+  const result = spawnSync(candidate, ["--version"], { stdio: "ignore", env });
   return result.status === 0;
 });
 
@@ -12,7 +51,7 @@ if (!python) {
 }
 
 for (const script of ["python/tests/toolkit_unit_tests.py", "python/hooks/test_hooks.py"]) {
-  const result = spawnSync(python, [script], { stdio: "inherit" });
+  const result = spawnSync(python, [script], { stdio: "inherit", env });
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }


### PR DESCRIPTION
## Problem
The **Readiness checks** lane has been red across PR #6/#7/#8: `npm run test:python` dies with `FileNotFoundError: 'recall'`. Root cause (reproduced locally by stripping `recall` from PATH): `python/hooks/test_hooks.py` invokes the `recall` binary by name in 8 guard/tracker/semantic tests, as a real install puts it on PATH, but CI builds the package via `npm ci` (prepare→build) and never links it.

## Fix
In the **test harness** (`scripts/run-python-tests.mjs`), not the shipped hooks (which correctly expect an installed `recall`): build the CLI if missing, then prepend a hermetic `recall` shim → this repo's own `dist/src/cli.js` to PATH for the test subprocesses (with `--disable-warning` so the experimental-sqlite notice doesn't pollute asserted stderr).

The suite now exercises the build under test and no longer depends on a global install, fixing CI **and** local contributors who haven't `npm link`ed `recall`.

## Verified
- Python suite **27/27** with `recall` stripped from PATH (CI condition).
- Python suite **27/27** normally (no regression).
- Only `test:python` needed the binary; `mcp-smoke`/`bench`/`install-smoke` don't (checked).