### PR TITLE
docs: realign README + banner to push-vs-pull positioning

### DIFF
--- a/.github/assets/recall-banner-dark.svg
+++ b/.github/assets/recall-banner-dark.svg
@@ -1,5 +1,5 @@
-<svg width="1280" height="360" viewBox="0 0 1280 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Recall — active memory substrate for LLM agents">
-  <title>Recall — active memory substrate for LLM agents</title>
+<svg width="1280" height="360" viewBox="0 0 1280 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Recall — push memory for AI agents">
+  <title>Recall — push memory for AI agents</title>
   <defs>
     <linearGradient id="bd-accent" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#2dd4bf"/>
@@ -36,8 +36,8 @@
   <text x="244" y="170" font-family="ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace" font-size="84" font-weight="700" letter-spacing="-2" fill="#f1f5f9">recall</text>
   <rect x="248" y="196" width="64" height="4" rx="2" fill="url(#bd-accent)"/>
   <text x="324" y="200" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" font-weight="500" fill="#5eead4">v0.2.0</text>
-  <text x="248" y="244" font-family="-apple-system, 'Segoe UI', Inter, system-ui, sans-serif" font-size="27" font-weight="400" fill="#94a3b8">Active memory substrate for LLM agents.</text>
-  <text x="248" y="282" font-family="-apple-system, 'Segoe UI', Inter, system-ui, sans-serif" font-size="20" font-weight="400" fill="#64748b">Local-first &#183; evidence-weighted &#183; auditable &#183; rollbackable</text>
+  <text x="248" y="244" font-family="-apple-system, 'Segoe UI', Inter, system-ui, sans-serif" font-size="27" font-weight="400" fill="#94a3b8">Push memory for AI agents.</text>
+  <text x="248" y="282" font-family="-apple-system, 'Segoe UI', Inter, system-ui, sans-serif" font-size="20" font-weight="400" fill="#64748b">Checks before it acts &#183; supersedes on its own &#183; local &amp; yours</text>
 
   <!-- constellation -->
   <g transform="translate(880, 60)" opacity="0.95">

--- a/.github/assets/recall-banner-light.svg
+++ b/.github/assets/recall-banner-light.svg
@@ -1,5 +1,5 @@
-<svg width="1280" height="360" viewBox="0 0 1280 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Recall — active memory substrate for LLM agents">
-  <title>Recall — active memory substrate for LLM agents</title>
+<svg width="1280" height="360" viewBox="0 0 1280 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Recall — push memory for AI agents">
+  <title>Recall — push memory for AI agents</title>
   <defs>
     <linearGradient id="bl-accent" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#0d9488"/>
@@ -36,8 +36,8 @@
   <text x="244" y="170" font-family="ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace" font-size="84" font-weight="700" letter-spacing="-2" fill="#0f172a">recall</text>
   <rect x="248" y="196" width="64" height="4" rx="2" fill="url(#bl-accent)"/>
   <text x="324" y="200" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="22" font-weight="500" fill="#0d9488">v0.2.0</text>
-  <text x="248" y="244" font-family="-apple-system, 'Segoe UI', Inter, system-ui, sans-serif" font-size="27" font-weight="400" fill="#475569">Active memory substrate for LLM agents.</text>
-  <text x="248" y="282" font-family="-apple-system, 'Segoe UI', Inter, system-ui, sans-serif" font-size="20" font-weight="400" fill="#94a3b8">Local-first &#183; evidence-weighted &#183; auditable &#183; rollbackable</text>
+  <text x="248" y="244" font-family="-apple-system, 'Segoe UI', Inter, system-ui, sans-serif" font-size="27" font-weight="400" fill="#475569">Push memory for AI agents.</text>
+  <text x="248" y="282" font-family="-apple-system, 'Segoe UI', Inter, system-ui, sans-serif" font-size="20" font-weight="400" fill="#94a3b8">Checks before it acts &#183; supersedes on its own &#183; local &amp; yours</text>
 
   <!-- constellation -->
   <g transform="translate(880, 60)">

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 <br/>
 <br/>
 
-**Disciplined, operable memory for LLM agents. Evidence-weighted, auditable, and compiled to a budget instead of poured back into the prompt.**
+**The memory layer your agent just uses — it remembers, corrects itself, and recalls across sessions on its own. Local, free, and yours.**
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-0d9488.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%E2%89%A524-0d9488.svg)](package.json)
-[![Tests](https://img.shields.io/badge/tests-140%20passing-2dd4bf.svg)](#development)
+[![Tests](https://img.shields.io/badge/tests-148%20passing-2dd4bf.svg)](#development)
 [![E2E](https://img.shields.io/badge/e2e-94%20checks-2dd4bf.svg)](scripts/e2e.mjs)
 [![Local-first](https://img.shields.io/badge/local--first-no%20cloud%20required-5eead4.svg)](#why-recall)
 [![Status](https://img.shields.io/badge/status-early%20runtime-f59e0b.svg)](#project-status)
@@ -36,14 +36,17 @@
 
 ---
 
-**Recall is disciplined, operable memory: a runtime, not a pile of notes.**
-Most agent "memory" is chat logs or a vector index that gets poured back
-into the prompt. With Recall, an LLM proposes a structured write, an
-admission firewall validates it, the graph store persists it as addressable
-cells and n-ary hyperedges in local SQLite, and the compiler returns only
-the relevant subgraph, ranked by evidence and fit to a word budget. Every
-fact carries provenance, confidence, and a rollback entry. You can inspect,
-question, and undo anything in it.
+**Most agent memory is _pull_: a store you query.** You ask, it returns the
+closest matches, and it is on you to notice when a fact has gone stale. Recall
+is _push_: the agent and the substrate run a loop together — it checks what it
+already knows before it acts, does the work, and writes back what it learned,
+_superseding_ the old fact when something changes and surfacing the
+contradiction without being asked. No reminding it to save, no separate cloud
+service mining your transcript after the fact. Under the hood an LLM proposes a
+structured write, an admission firewall validates it, and the compiler returns
+only the relevant subgraph — ranked by evidence, fit to a word budget — all in
+local SQLite: no server, no account, no cloud. The memory is yours, and every
+fact still carries provenance, confidence, and a one-command undo.
 
 One installable Node.js tool: CLI, read-only TUI, MCP server, quiet
 maintenance daemon, strict write schema, semantic search, encrypted secrets
@@ -215,9 +218,7 @@ memory that stays *honest* — the whole point of Recall over a flat note file.
 
 Every Recall capability has a short, honest screencast — real CLI, real output,
 an isolated graph — with the **full script and the unedited transcript** beside
-each clip. Browse them all in the **[companion gallery](https://h-xx-d.github.io/recall-demos/)**,
-or watch the walkthroughs on the **[YouTube channel](https://www.youtube.com/@YOUR_CHANNEL)**
-*(channel link — fill in)*.
+each clip. Browse them all in the **[companion gallery](https://h-xx-d.github.io/recall-demos/)**.
 
 | Screencast | What it shows |
 |---|---|


### PR DESCRIPTION
Re-points the highest-traffic surface (README + banner) onto the corrected positioning axis: **the memory layer your agent just uses, local, free, yours**, with **push vs pull** explained explicitly, not auditability-forward.

## README
- **Tagline** → "The memory layer your agent just uses, it remembers, corrects itself, and recalls across sessions on its own. Local, free, and yours."
- **Opening paragraph** → now explains push vs pull directly: *pull = a store you query; Recall = push, an agent+substrate loop that checks before it acts and supersedes on its own.* Auditability/provenance/rollback demoted to "under the hood."
- Removed the **dead `@YOUR_CHANNEL`** placeholder link (gallery link stays, it's live).
- **Tests badge 140 → 148** (matches the suite after the repair PR).

## Banner (light + dark)
- Main line → **"Push memory for AI agents."**
- Sub-line → **"Checks before it acts · supersedes on its own · local & yours"** (was "Local-first · evidence-weighted · auditable · rollbackable").
- Alt/title updated. Visual (hexagon mark + memory-graph constellation) unchanged.
- **Render-verified** on both light and dark themes (no overflow; layout intact).

## Review note
Eyeball the rendered banner in the file diff / README preview, copy is a same-length text swap with layout untouched, so it should match the local render.