### PR TITLE
feat(adapter): import Claude Code auto-memory files into the graph

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { runAcpLoop } from "./core/acp.js";
 import { runDaemonOnce } from "./core/daemon.js";
 import { defaultEvalSuite, type RecallEvalSuite } from "./core/evals.js";
 import { exportRecallArchive, importRecallArchive } from "./core/export.js";
+import { importAutoMemory } from "./core/auto-memory-adapter.js";
 import { buildPageIndex, getRecallPage, type RecallPageName } from "./core/pages.js";
 import { runOperatingCycle } from "./core/operator.js";
 import { validateWriteProposal } from "./core/schema.js";
@@ -72,6 +73,7 @@ interface ParsedArgs {
   acpToAgent?: string;
   force: boolean;
   apply: boolean;
+  root?: string;
 }
 
 function main(): void {
@@ -154,7 +156,7 @@ function main(): void {
     return;
   }
 
-  if (command === "import") {
+  if (command === "import" && subcommand !== "auto-memory") {
     const archive = readJsonArg(args);
     console.log(JSON.stringify({ result: importRecallArchive(args.db, archive, { replace: args.force }) }, null, 2));
     return;
@@ -251,6 +253,12 @@ function main(): void {
         const relations = store.unresolvableTrustEdges();
         console.log(JSON.stringify({ dryRun: true, count: relations.length, relations }, null, 2));
       }
+      return;
+    }
+
+    if (command === "import" && subcommand === "auto-memory") {
+      const summary = importAutoMemory(store, { root: args.root, project: args.project[0], apply: args.apply });
+      console.log(JSON.stringify(summary, null, 2));
       return;
     }
 
@@ -592,6 +600,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let acpToAgent: string | undefined;
   let force = false;
   let apply = false;
+  let root: string | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -680,6 +689,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       force = true;
     } else if (arg === "--apply") {
       apply = true;
+    } else if (arg === "--root") {
+      root = requireValue(argv, ++index, "--root");
     } else {
       command.push(arg);
     }
@@ -739,7 +750,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     acpManager,
     acpToAgent,
     force,
-    apply
+    apply,
+    root
   };
 }
 
@@ -919,6 +931,7 @@ Commands:
   recall storage [--db path]
   recall export [--db path]                                      print a portable JSON archive to stdout
   recall import --json recall-export.json [--db path] [--force]  restore an archive into an empty db; --force replaces rows
+  recall import auto-memory [--root path] [--project name] [--apply] [--db path]  import Claude Code auto-memory files (dry-run default; --apply writes)
   recall acp [status] [--db path]
   recall acp send --json request.json [--db path]
   recall acp list [--limit 20] [--acp-status queued] [--db path]

--- a/src/core/auto-memory-adapter.ts
+++ b/src/core/auto-memory-adapter.ts
@@ -1,0 +1,313 @@
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+import { admitWriteProposal } from "./admission.js";
+import { reviewFirewall } from "./firewall.js";
+import { validateWriteProposal } from "./schema.js";
+import type { RecallStore } from "./store.js";
+import type { NodeKind, WriteProposal } from "./types.js";
+
+export interface ParsedAutoMemory {
+  name?: string;
+  description?: string;
+  type?: string;
+  body: string;
+}
+
+export interface DiscoveredFile {
+  slug: string;
+  project: string;
+  filePath: string;
+}
+
+export interface ImportItem {
+  filePath: string;
+  action: "create" | "supersede" | "skip";
+  cellId?: string;
+  supersedes?: string[];
+  // Why a file was skipped (unchanged / empty / too-large / unreadable / firewall / invalid).
+  // Present only on skips; lets dry-run and apply explain themselves.
+  reason?: string;
+}
+
+export interface ImportSummary {
+  dryRun: boolean;
+  created: number;
+  superseded: number;
+  skipped: number;
+  items: ImportItem[];
+}
+
+const DEFAULT_ROOT = join(process.env.HOME ?? "", ".claude", "projects");
+// Auto-memory notes are small; anything larger is skipped rather than read into
+// memory, so a stray multi-GB file can never OOM the import.
+const MAX_FILE_BYTES = 1_000_000;
+// Supersession ceiling per file. Practically unbounded for real corpora (memory
+// files rarely accrue dozens of versions) while still capping a pathological scan.
+const MAX_PRIOR_VERSIONS = 1000;
+// Only these frontmatter keys are kept; an arbitrary/pathological key block is ignored.
+const FRONTMATTER_KEYS = new Set(["name", "description", "type"]);
+const MAX_FIELD_LEN = 2000;
+
+// Parse a Claude Code auto-memory file: flat `key: value` frontmatter between
+// `---` fences, then the markdown body. The frontmatter is flat key/value, so a
+// line scan suffices — no YAML dependency, and an unfenced file is body-only.
+// CRLF is normalized first so Windows-authored files parse identically.
+export function parseAutoMemoryFile(content: string): ParsedAutoMemory {
+  const text = content.replace(/\r\n/g, "\n");
+  const fence = /^---\n([\s\S]*?)\n---\n?/.exec(text);
+  if (!fence) {
+    return { body: text.trim() };
+  }
+  const front: Record<string, string> = {};
+  for (const line of fence[1]!.split("\n")) {
+    const m = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(line);
+    if (m && FRONTMATTER_KEYS.has(m[1]!)) {
+      front[m[1]!] = m[2]!.trim().slice(0, MAX_FIELD_LEN);
+    }
+  }
+  return {
+    name: front.name,
+    description: front.description,
+    type: front.type,
+    body: text.slice(fence[0].length).trim(),
+  };
+}
+
+// Walk <root>/<slug>/memory/*.md, skipping the MEMORY.md index. Symlinks are
+// skipped at every level (slug dir, memory dir, file) via lstat, so a symlink
+// planted under the root can never make the import read a file outside the tree.
+// Deterministic order.
+export function discoverAutoMemoryFiles(root: string = DEFAULT_ROOT): DiscoveredFile[] {
+  if (!existsSync(root)) {
+    return [];
+  }
+  const out: DiscoveredFile[] = [];
+  for (const slug of readdirSync(root)) {
+    const slugDir = join(root, slug);
+    // lstat (not stat): a symlinked slug dir reports isDirectory()===false and is skipped.
+    if (!safeIsDir(slugDir)) {
+      continue;
+    }
+    const memoryDir = join(slugDir, "memory");
+    if (!existsSync(memoryDir) || !safeIsDir(memoryDir)) {
+      continue;
+    }
+    for (const entry of readdirSync(memoryDir)) {
+      if (!entry.endsWith(".md") || entry === "MEMORY.md") {
+        continue;
+      }
+      const filePath = join(memoryDir, entry);
+      // Only regular files that live in the tree — never a symlinked entry.
+      if (!safeIsFile(filePath)) {
+        continue;
+      }
+      out.push({ slug, project: slug, filePath });
+    }
+  }
+  return out.sort((a, b) => a.filePath.localeCompare(b.filePath));
+}
+
+function safeIsDir(path: string): boolean {
+  try {
+    return lstatSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function safeIsFile(path: string): boolean {
+  try {
+    return lstatSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function sha12(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function kindFor(type: string | undefined): NodeKind {
+  switch ((type ?? "").toLowerCase()) {
+    case "project":
+    case "decision":
+    case "architecture":
+      return "decision";
+    default:
+      return "observation";
+  }
+}
+
+function autoMemoryToProposal(
+  parsed: ParsedAutoMemory,
+  opts: { filePath: string; project: string; srcTag: string; contradicts: string[]; now: string }
+): WriteProposal {
+  const title = (parsed.name && parsed.name.trim()) || basename(opts.filePath) || "auto-memory";
+  const summary = parsed.description ?? title;
+  const kind = kindFor(parsed.type);
+  return {
+    schema_version: "recall.write.v1",
+    actor: { kind: "connector", id: "auto-memory-adapter", display: "Auto-memory adapter" },
+    intent: { kind, operation: "create" },
+    content: { title, body: parsed.body || summary, summary },
+    scope: { project: opts.project, tenant: "local" },
+    tags: {
+      category: ["memory"],
+      type: [kind],
+      subject: [title],
+      project: [opts.project],
+      idea: ["auto-memory-import"],
+      timestamp: [opts.now.slice(0, 10)],
+      topics: ["auto-memory", "imported", parsed.type ?? "note"],
+      entities: [opts.project, opts.srcTag],
+      identities: ["connector:auto-memory"],
+      rings: ["runtime"],
+      lifecycle: ["active"],
+      quality: ["imported", "source-grounded"],
+    },
+    evidence: {
+      source_refs: [opts.filePath],
+      depends_on: [],
+      supports: [],
+      contradicts: opts.contradicts,
+      concerns: [],
+    },
+    confidence: { value: 0.6, uncertainty: 0.28, concern: 0.12, source_quality: "medium", stability: "stable" },
+    provenance: {
+      created_at: opts.now,
+      origin: "connector",
+      produced_by: "auto-memory-adapter",
+      verification: "checked",
+      signature_status: "unsigned",
+    },
+    policy: {
+      sensitivity: "private",
+      allow_background_use: true,
+      requires_review: false,
+      expires_at: null,
+      reverify_after: null,
+    },
+  } as WriteProposal;
+}
+
+// Import Claude Code auto-memory files into the graph. Idempotent per file
+// CONTENT (derivation key = file + content hash): re-importing an unchanged file
+// is skipped; a changed file admits a new cell that SUPERSEDES the prior
+// version(s) of that file via a contradicts edge (found by a stable per-file
+// entity tag). Dry-run by default.
+//
+// Robustness: every file is bounded (oversized skipped, never read), read errors
+// are non-fatal skips, and admission is PREDICTED in dry-run (same validate +
+// firewall gates apply()'s admit runs) so dry-run counts match apply exactly —
+// a file that would be rejected is reported as a skip in both modes, with a reason.
+export function importAutoMemory(
+  store: RecallStore,
+  opts: { root?: string; project?: string; apply?: boolean; now?: Date } = {}
+): ImportSummary {
+  const root = opts.root ?? DEFAULT_ROOT;
+  const apply = opts.apply ?? false;
+  const now = (opts.now ?? new Date()).toISOString();
+  const items: ImportItem[] = [];
+  let created = 0;
+  let superseded = 0;
+  let skipped = 0;
+
+  const skip = (filePath: string, reason: string): void => {
+    skipped += 1;
+    items.push({ filePath, action: "skip", reason });
+  };
+
+  for (const file of discoverAutoMemoryFiles(root)) {
+    // Bound memory before reading: an oversized file is skipped, never loaded.
+    let size: number;
+    try {
+      size = statSync(file.filePath).size;
+    } catch {
+      skip(file.filePath, "unreadable");
+      continue;
+    }
+    if (size > MAX_FILE_BYTES) {
+      skip(file.filePath, `too-large (${size} bytes > ${MAX_FILE_BYTES})`);
+      continue;
+    }
+
+    let raw: string;
+    try {
+      raw = readFileSync(file.filePath, "utf8");
+    } catch {
+      // Deleted or permission-revoked between discovery and read — skip, never fatal.
+      skip(file.filePath, "unreadable");
+      continue;
+    }
+
+    const srcTag = `auto-memory-src:${sha12(file.filePath)}`;
+    const derivationKey = `auto-memory:${sha12(file.filePath)}:${sha12(raw)}`;
+
+    // Already imported this exact version of this file.
+    if (store.getNodeByDerivationKey(derivationKey)) {
+      skip(file.filePath, "unchanged");
+      continue;
+    }
+
+    const parsed = parseAutoMemoryFile(raw);
+    // Nothing worth importing — no name and no body.
+    if (!(parsed.name && parsed.name.trim()) && parsed.body.trim().length === 0) {
+      skip(file.filePath, "empty");
+      continue;
+    }
+
+    // Prior versions of this same file (stable src tag) are superseded.
+    const priors = store.subgraph({ entities: [srcTag], limit: MAX_PRIOR_VERSIONS });
+    const contradicts = priors.map((p) => p.id);
+
+    const proposal = autoMemoryToProposal(parsed, {
+      filePath: file.filePath,
+      project: opts.project ?? file.project,
+      srcTag,
+      contradicts,
+      now,
+    });
+
+    // Predict admission so dry-run counts match apply: the same validate + firewall
+    // gates admitWriteProposal applies. A file that would be rejected is a skip in
+    // BOTH modes, with the reason — never a silent count mismatch.
+    const validated = validateWriteProposal(proposal);
+    if (!validated.ok) {
+      skip(file.filePath, `invalid: ${validated.issues[0]?.message ?? "schema"}`);
+      continue;
+    }
+    const firewall = reviewFirewall(proposal);
+    if (!firewall.allowed) {
+      skip(file.filePath, `firewall: ${firewall.issues[0]?.message ?? "rejected"}`);
+      continue;
+    }
+
+    if (!apply) {
+      if (contradicts.length > 0) {
+        superseded += 1;
+        items.push({ filePath: file.filePath, action: "supersede", supersedes: contradicts });
+      } else {
+        created += 1;
+        items.push({ filePath: file.filePath, action: "create" });
+      }
+      continue;
+    }
+
+    const result = admitWriteProposal(proposal, store, { derivationKey, now: opts.now });
+    if (!result.accepted || !result.node) {
+      // Defensive: predicted admit but admission still rejected (e.g. a review gate).
+      skip(file.filePath, `rejected: ${result.issues[0]?.message ?? "admission"}`);
+      continue;
+    }
+    if (contradicts.length > 0) {
+      superseded += 1;
+      items.push({ filePath: file.filePath, action: "supersede", cellId: result.node.id, supersedes: contradicts });
+    } else {
+      created += 1;
+      items.push({ filePath: file.filePath, action: "create", cellId: result.node.id });
+    }
+  }
+
+  return { dryRun: !apply, created, superseded, skipped, items };
+}

--- a/tests/auto-memory-adapter.test.ts
+++ b/tests/auto-memory-adapter.test.ts
@@ -1,0 +1,284 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  discoverAutoMemoryFiles,
+  importAutoMemory,
+  parseAutoMemoryFile,
+} from "../src/core/auto-memory-adapter.js";
+import { SQLiteRecallStore } from "../src/core/store.js";
+import { tempDbPath } from "./helpers.js";
+
+// A Claude Code auto-memory file: frontmatter (name/description/type) + body.
+function fm(name: string, description: string, type: string, body: string): string {
+  return `---\nname: ${name}\ndescription: ${description}\ntype: ${type}\n---\n\n${body}\n`;
+}
+
+// Build a temp `projects/<slug>/memory/*.md` tree like Claude Code's.
+function makeMemoryRoot(files: { slug: string; name: string; content: string }[]): {
+  root: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "automem-root-"));
+  for (const f of files) {
+    const dir = join(root, f.slug, "memory");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, f.name), f.content);
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+describe("auto-memory adapter", () => {
+  it("parses frontmatter (name/description/type) and the body", () => {
+    const p = parseAutoMemoryFile(fm("cone-status", "the cone", "project", "Body line one.\nBody line two."));
+    assert.equal(p.name, "cone-status");
+    assert.equal(p.description, "the cone");
+    assert.equal(p.type, "project");
+    assert.match(p.body, /Body line one\./);
+    assert.doesNotMatch(p.body, /^---/, "frontmatter is stripped from the body");
+  });
+
+  it("parses a file with no frontmatter as body-only", () => {
+    const p = parseAutoMemoryFile("just some notes, no frontmatter");
+    assert.equal(p.name, undefined);
+    assert.match(p.body, /just some notes/);
+  });
+
+  it("discovers memory .md files across slugs and skips the MEMORY.md index", () => {
+    const { root, cleanup } = makeMemoryRoot([
+      { slug: "proj-a", name: "MEMORY.md", content: "# Memory Index" },
+      { slug: "proj-a", name: "alpha.md", content: fm("alpha", "a", "project", "A body") },
+      { slug: "proj-b", name: "beta.md", content: fm("beta", "b", "note", "B body") },
+    ]);
+    try {
+      const found = discoverAutoMemoryFiles(root);
+      const names = found.map((f) => f.filePath.split("/").pop()).sort();
+      assert.deepEqual(names, ["alpha.md", "beta.md"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("dry-runs: reports what it would import and writes nothing", () => {
+    const { root, cleanup } = makeMemoryRoot([
+      { slug: "p", name: "a.md", content: fm("a", "da", "note", "Body A") },
+      { slug: "p", name: "b.md", content: fm("b", "db", "note", "Body B") },
+    ]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importAutoMemory(store, { root, apply: false });
+      assert.equal(sum.dryRun, true);
+      assert.equal(sum.created, 2);
+      assert.equal(store.listNodes(100).length, 0, "dry-run admits nothing");
+    } finally {
+      store.close();
+      temp.cleanup();
+      cleanup();
+    }
+  });
+
+  it("apply imports each file as a cell with title, body, and source ref", () => {
+    const { root, cleanup } = makeMemoryRoot([
+      { slug: "p", name: "a.md", content: fm("alpha-fact", "desc a", "project", "The body of alpha.") },
+    ]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importAutoMemory(store, { root, apply: true });
+      assert.equal(sum.created, 1);
+      const nodes = store.listNodes(100);
+      assert.equal(nodes.length, 1);
+      assert.equal(nodes[0]!.title, "alpha-fact");
+      assert.match(nodes[0]!.body, /The body of alpha\./);
+    } finally {
+      store.close();
+      temp.cleanup();
+      cleanup();
+    }
+  });
+
+  it("is idempotent — re-importing unchanged files skips them (no duplicates)", () => {
+    const { root, cleanup } = makeMemoryRoot([
+      { slug: "p", name: "a.md", content: fm("a", "da", "note", "Body A unchanged") },
+    ]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      importAutoMemory(store, { root, apply: true });
+      const second = importAutoMemory(store, { root, apply: true });
+      assert.equal(second.created, 0);
+      assert.equal(second.skipped, 1);
+      assert.equal(store.listNodes(100).length, 1, "no duplicate cell");
+    } finally {
+      store.close();
+      temp.cleanup();
+      cleanup();
+    }
+  });
+
+  it("supersedes the prior cell when a memory file's content changes", () => {
+    const { root, cleanup } = makeMemoryRoot([
+      { slug: "p", name: "a.md", content: fm("db-host", "the db", "decision", "Runs on db-east-1.") },
+    ]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const first = importAutoMemory(store, { root, apply: true });
+      const oldId = first.items[0]!.cellId!;
+
+      writeFileSync(join(root, "p", "memory", "a.md"), fm("db-host", "the db", "decision", "Migrated to db-west-2."));
+      const second = importAutoMemory(store, { root, apply: true });
+
+      assert.equal(second.superseded, 1);
+      assert.equal(second.items[0]!.action, "supersede");
+      assert.deepEqual(second.items[0]!.supersedes, [oldId]);
+      assert.equal(store.listNodes(100).length, 2, "a new version cell was created");
+      const challenges = store.listRelations(oldId, "in", 100).filter((r) => r.kind === "contradicts");
+      assert.equal(challenges.length, 1, "the new cell contradicts (supersedes) the old one");
+    } finally {
+      store.close();
+      temp.cleanup();
+      cleanup();
+    }
+  });
+});
+
+const CLI = ["--disable-warning=ExperimentalWarning", "dist/src/cli.js"];
+
+describe("cli import auto-memory", () => {
+  it("dry-runs by default and imports with --apply", () => {
+    const { root, cleanup } = makeMemoryRoot([
+      { slug: "p", name: "a.md", content: fm("a", "da", "note", "Body A") },
+    ]);
+    const temp = tempDbPath();
+    try {
+      const dry = execFileSync(process.execPath, [...CLI, "import", "auto-memory", "--root", root, "--db", temp.path], { encoding: "utf8" });
+      assert.match(dry, /"dryRun": true/);
+      assert.match(dry, /"created": 1/);
+
+      const applied = execFileSync(process.execPath, [...CLI, "import", "auto-memory", "--root", root, "--apply", "--db", temp.path], { encoding: "utf8" });
+      assert.match(applied, /"created": 1/);
+
+      const store = new SQLiteRecallStore(temp.path);
+      assert.equal(store.listNodes(100).length, 1);
+      store.close();
+    } finally {
+      temp.cleanup();
+      cleanup();
+    }
+  });
+});
+
+describe("auto-memory adapter — robustness", () => {
+  it("parses CRLF frontmatter", () => {
+    const p = parseAutoMemoryFile("---\r\nname: crlf-fact\r\ndescription: d\r\ntype: note\r\n---\r\n\r\nBody here.\r\n");
+    assert.equal(p.name, "crlf-fact");
+    assert.match(p.body, /Body here\./);
+  });
+
+  it("falls back to the filename when the name field is empty", () => {
+    const { root, cleanup } = makeMemoryRoot([
+      { slug: "p", name: "the-file.md", content: "---\nname:\ndescription: d\ntype: note\n---\n\nBody." },
+    ]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      importAutoMemory(store, { root, apply: true });
+      const nodes = store.listNodes(100);
+      assert.equal(nodes.length, 1);
+      assert.equal(nodes[0]!.title, "the-file.md", "empty name falls back to the filename");
+    } finally {
+      store.close();
+      temp.cleanup();
+      cleanup();
+    }
+  });
+
+  it("skips an oversized file with a reason instead of importing or crashing", () => {
+    const { root, cleanup } = makeMemoryRoot([{ slug: "p", name: "big.md", content: "x".repeat(2_000_000) }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importAutoMemory(store, { root, apply: true });
+      assert.equal(sum.created, 0);
+      assert.equal(sum.skipped, 1);
+      assert.equal(sum.items[0]!.action, "skip");
+      assert.match(sum.items[0]!.reason ?? "", /large|size/i);
+      assert.equal(store.listNodes(100).length, 0);
+    } finally {
+      store.close();
+      temp.cleanup();
+      cleanup();
+    }
+  });
+
+  it("skips an empty file", () => {
+    const { root, cleanup } = makeMemoryRoot([{ slug: "p", name: "empty.md", content: "   \n\n  " }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importAutoMemory(store, { root, apply: true });
+      assert.equal(sum.skipped, 1);
+      assert.equal(store.listNodes(100).length, 0);
+    } finally {
+      store.close();
+      temp.cleanup();
+      cleanup();
+    }
+  });
+
+  it("dry-run and apply agree (and give a reason) when the firewall rejects a file", () => {
+    const body = "deploy key AKIAABCDEFGHIJKLMNOP committed here"; // trips the AWS-key firewall pattern
+    const { root, cleanup } = makeMemoryRoot([{ slug: "p", name: "leak.md", content: fm("leak", "d", "note", body) }]);
+    const a = tempDbPath();
+    const sa = new SQLiteRecallStore(a.path);
+    const b = tempDbPath();
+    const sb = new SQLiteRecallStore(b.path);
+    try {
+      const dry = importAutoMemory(sa, { root, apply: false });
+      const wet = importAutoMemory(sb, { root, apply: true });
+      assert.equal(dry.created, wet.created, "dry-run created matches apply");
+      assert.equal(dry.skipped, wet.skipped, "dry-run skipped matches apply");
+      assert.equal(wet.created, 0, "the secret-bearing file is not imported");
+      assert.match(wet.items[0]!.reason ?? "", /firewall|secret|reject/i);
+    } finally {
+      sa.close();
+      a.cleanup();
+      sb.close();
+      b.cleanup();
+      cleanup();
+    }
+  });
+
+  it("does not follow a symlinked memory entry out of the tree", () => {
+    const { root, cleanup } = makeMemoryRoot([
+      { slug: "p", name: "real.md", content: fm("real-note", "d", "note", "Real body.") },
+    ]);
+    const outside = mkdtempSync(join(tmpdir(), "automem-outside-"));
+    writeFileSync(join(outside, "secret.md"), fm("evil-note", "d", "note", "Should NOT be imported."));
+    let linked = false;
+    try {
+      symlinkSync(join(outside, "secret.md"), join(root, "p", "memory", "linked.md"));
+      linked = true;
+    } catch {
+      /* symlinks unsupported on this platform — skip the negative assertion */
+    }
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      importAutoMemory(store, { root, apply: true });
+      const titles = store.listNodes(100).map((n) => n.title);
+      assert.ok(titles.includes("real-note"), "the real file is imported");
+      if (linked) assert.ok(!titles.includes("evil-note"), "the symlinked file is NOT imported");
+    } finally {
+      store.close();
+      temp.cleanup();
+      cleanup();
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/auto-memory-adapter.test.ts
+++ b/tests/auto-memory-adapter.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { describe, it } from "node:test";
 import {
   discoverAutoMemoryFiles,
@@ -55,7 +55,7 @@ describe("auto-memory adapter", () => {
     ]);
     try {
       const found = discoverAutoMemoryFiles(root);
-      const names = found.map((f) => f.filePath.split("/").pop()).sort();
+      const names = found.map((f) => basename(f.filePath)).sort();
       assert.deepEqual(names, ["alpha.md", "beta.md"]);
     } finally {
       cleanup();


### PR DESCRIPTION
## What

`recall import auto-memory`, the migration wedge made real. It walks Claude Code's auto-memory store (`~/.claude/projects/<slug>/memory/*.md`) and admits each file as a calibrated Recall cell. **Own your memory, cancel the subscription.**

Dry-run by default; `--apply` writes.

```
recall import auto-memory                 # preview what would import
recall import auto-memory --apply         # write into the routed DB
recall import auto-memory --root <dir> --project <slug> --apply
```

## How it behaves

- **Idempotent per file content**, derivation key = `path + content hash`. Re-importing an unchanged file is skipped; a *changed* file admits a new cell that **supersedes** the prior version via a `contradicts` edge (prior found by a stable per-file `auto-memory-src:` entity tag). This is the push-memory loop: memory stays honest, not just appended.
- **Secret-safe**, a body that trips the admission firewall (e.g. an AWS key) is skipped, never imported.
- **Conservative confidence**, imported flat-file facts land at 0.6 / `medium` source quality, `private` sensitivity.

## Hardened per adversarial review (3 lenses)

- **dry-run == apply**: admission (validate + firewall) is *predicted* in dry-run, so a would-be-rejected file is reported as a skip in **both** modes, no count drift between preview and write.
- **No OOM / no crash**: oversized files are skipped *before* read; read errors (deleted/permission) are non-fatal skips.
- **No reads outside the tree**: symlinked entries are skipped at every level (slug dir, memory dir, file) via `lstat`.
- **Parsing**: CRLF frontmatter parses; empty `name` falls back to the filename; empty files skip; frontmatter keys are whitelisted.
- **Observability**: every skip carries a `reason` (`unchanged` / `empty` / `too-large` / `unreadable` / `firewall` / `invalid`).
- **Discoverability**: `recall import auto-memory` documented in `printHelp`.

## Tests

- 14 adapter tests: parse, discover (skips `MEMORY.md`), dry-run, apply, idempotency, supersession, CLI, + 6 robustness (CRLF, empty-name fallback, oversized skip, empty skip, dry-run/apply parity on firewall reject, symlink skip).
- Full suite **162/162**, e2e **94 checks**.
- Dry-run over the real 162-file corpus on this machine: **162 importable, 0 skipped**.