### PR TITLE
feat(adapter): Mem0 and Zep export importers (migration wedge)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,8 @@ import { runDaemonOnce } from "./core/daemon.js";
 import { defaultEvalSuite, type RecallEvalSuite } from "./core/evals.js";
 import { exportRecallArchive, importRecallArchive } from "./core/export.js";
 import { importAutoMemory } from "./core/auto-memory-adapter.js";
+import { importMem0 } from "./core/mem0-adapter.js";
+import { importZep } from "./core/zep-adapter.js";
 import { buildPageIndex, getRecallPage, type RecallPageName } from "./core/pages.js";
 import { runOperatingCycle } from "./core/operator.js";
 import { validateWriteProposal } from "./core/schema.js";
@@ -74,6 +76,7 @@ interface ParsedArgs {
   force: boolean;
   apply: boolean;
   root?: string;
+  file?: string;
 }
 
 function main(): void {
@@ -156,7 +159,7 @@ function main(): void {
     return;
   }
 
-  if (command === "import" && subcommand !== "auto-memory") {
+  if (command === "import" && subcommand !== "auto-memory" && subcommand !== "mem0" && subcommand !== "zep") {
     const archive = readJsonArg(args);
     console.log(JSON.stringify({ result: importRecallArchive(args.db, archive, { replace: args.force }) }, null, 2));
     return;
@@ -258,6 +261,40 @@ function main(): void {
 
     if (command === "import" && subcommand === "auto-memory") {
       const summary = importAutoMemory(store, { root: args.root, project: args.project[0], apply: args.apply });
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+
+    if (command === "import" && subcommand === "mem0") {
+      const file = args.file;
+      if (!file) {
+        fail("recall import mem0 requires --file <export.json>");
+        return;
+      }
+      let summary;
+      try {
+        summary = importMem0(store, { file, project: args.project[0], apply: args.apply });
+      } catch (error) {
+        fail(error instanceof Error ? error.message : String(error));
+        return;
+      }
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+
+    if (command === "import" && subcommand === "zep") {
+      const file = args.file;
+      if (!file) {
+        fail("recall import zep requires --file <export.json>");
+        return;
+      }
+      let summary;
+      try {
+        summary = importZep(store, { file, project: args.project[0], apply: args.apply });
+      } catch (error) {
+        fail(error instanceof Error ? error.message : String(error));
+        return;
+      }
       console.log(JSON.stringify(summary, null, 2));
       return;
     }
@@ -601,6 +638,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let force = false;
   let apply = false;
   let root: string | undefined;
+  let file: string | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -691,6 +729,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       apply = true;
     } else if (arg === "--root") {
       root = requireValue(argv, ++index, "--root");
+    } else if (arg === "--file") {
+      file = requireValue(argv, ++index, "--file");
     } else {
       command.push(arg);
     }
@@ -751,7 +791,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     acpToAgent,
     force,
     apply,
-    root
+    root,
+    file
   };
 }
 
@@ -932,6 +973,8 @@ Commands:
   recall export [--db path]                                      print a portable JSON archive to stdout
   recall import --json recall-export.json [--db path] [--force]  restore an archive into an empty db; --force replaces rows
   recall import auto-memory [--root path] [--project name] [--apply] [--db path]  import Claude Code auto-memory files (dry-run default; --apply writes)
+  recall import mem0 --file export.json [--project name] [--apply] [--db path]  import a Mem0 export (get_all/create_memory_export) as calibrated cells (dry-run default)
+  recall import zep --file export.json [--project name] [--apply] [--db path]   import a Zep graph export; reconstructs supersession from bi-temporal facts (dry-run default)
   recall acp [status] [--db path]
   recall acp send --json request.json [--db path]
   recall acp list [--limit 20] [--acp-status queued] [--db path]

--- a/src/core/import-core.ts
+++ b/src/core/import-core.ts
@@ -1,0 +1,186 @@
+import { readFileSync, statSync } from "node:fs";
+import { admitWriteProposal } from "./admission.js";
+import { reviewFirewall } from "./firewall.js";
+import { validateWriteProposal } from "./schema.js";
+import type { RecallStore } from "./store.js";
+import type { WriteProposal } from "./types.js";
+
+// One source record normalized for admission. The adapter (mem0/zep) turns its
+// export format into a list of these; the core handles dedup, supersession, the
+// admission firewall, and dry-run/apply parity uniformly.
+export interface ImportItem {
+  // Stable identifier for reporting (e.g. mem0 memory id, zep fact uuid).
+  ref: string;
+  // Idempotency key (source id + content hash). Re-importing an unchanged record skips.
+  derivationKey: string;
+  // This record's stable identity tag. Re-importing the SAME record with changed
+  // content supersedes the prior version found by this tag. The proposal MUST
+  // carry this tag in `tags.entities` so the prior is findable.
+  srcTag: string;
+  // srcTags of OTHER source records this record supersedes (e.g. a Zep fact that
+  // invalidates an earlier fact about the same predicate). Resolved to prior cell
+  // ids and added to the contradicts set.
+  supersedesTags?: string[];
+  // Build the proposal with the resolved contradicts cell ids injected.
+  toProposal: (contradicts: string[]) => WriteProposal;
+}
+
+export interface ImportResultItem {
+  ref: string;
+  action: "create" | "supersede" | "skip";
+  cellId?: string;
+  supersedes?: string[];
+  // Present only on skips: unchanged / invalid / firewall / rejected.
+  reason?: string;
+}
+
+export interface ImportSummary {
+  source: string;
+  dryRun: boolean;
+  created: number;
+  superseded: number;
+  skipped: number;
+  items: ImportResultItem[];
+}
+
+const MAX_PRIORS = 1000;
+
+// Bound memory: an export larger than this is rejected before reading, so a
+// pathological multi-GB file can never OOM the process (also under V8's string
+// limit). Generous enough for real exports; split a larger one.
+export const MAX_IMPORT_BYTES = 134_217_728; // 128 MB
+// Per-record body cap. Bounds both stored size and the firewall's per-record
+// regex scan cost. Admission itself warns around this size for a single body.
+export const MAX_BODY = 32_768;
+
+// Read and JSON-parse an import export file, bounding memory first. A missing or
+// unreadable file, an oversized file, or invalid JSON each raise a clear, labeled
+// Error (the caller routes it through the CLI's fail() path).
+export function readImportFile(file: string, label: string, maxBytes: number = MAX_IMPORT_BYTES): unknown {
+  let size: number;
+  try {
+    size = statSync(file).size;
+  } catch {
+    throw new Error(`${label} import: cannot read export file: ${file}`);
+  }
+  if (size > maxBytes) {
+    throw new Error(`${label} import: export file too large (${size} bytes > ${maxBytes}); split it before importing`);
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch {
+    throw new Error(`${label} import: cannot read export file: ${file}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${label} import: export file is not valid JSON: ${file}`);
+  }
+}
+
+// Clamp a record body so a single huge record can't bloat storage or amplify the
+// firewall scan. The clamped text is exactly what the firewall scans and what is
+// stored — the truncated tail is never admitted, so this cannot bypass the firewall.
+export function clampBody(text: string): string {
+  return text.length > MAX_BODY ? text.slice(0, MAX_BODY) : text;
+}
+
+// Admit a list of normalized import items. Processed in order, so a record that
+// supersedes an earlier record in the same batch (Zep bi-temporal chains) sees
+// its predecessor already admitted and links to it. Dry-run predicts admission
+// (validate + firewall) so its counts match apply exactly.
+export function admitImportItems(
+  store: RecallStore,
+  source: string,
+  items: ImportItem[],
+  opts: { apply: boolean; now?: Date }
+): ImportSummary {
+  const apply = opts.apply;
+  const result: ImportResultItem[] = [];
+  let created = 0;
+  let superseded = 0;
+  let skipped = 0;
+  // srcTags that have been (predicted-)admitted this run, so dry-run can resolve a
+  // same-batch predecessor the same way apply does (via the store).
+  const admitted = new Set<string>();
+
+  const skip = (ref: string, reason: string): void => {
+    skipped += 1;
+    result.push({ ref, action: "skip", reason });
+  };
+
+  for (const item of items) {
+    // Already imported this exact version of this record.
+    if (store.getNodeByDerivationKey(item.derivationKey)) {
+      skip(item.ref, "unchanged");
+      continue;
+    }
+
+    // Resolve priors to supersede: prior versions of this same record (own
+    // srcTag) plus any other records named in supersedesTags. In dry-run a
+    // same-batch predecessor is not yet admitted, so its cell id is unresolved —
+    // intent is still tracked via supersedesTags below.
+    const tags = [item.srcTag, ...(item.supersedesTags ?? [])];
+    const priorIds = uniquePriorIds(store, tags);
+
+    const proposal = item.toProposal(priorIds);
+
+    // Predict admission so dry-run counts match apply.
+    const validated = validateWriteProposal(proposal);
+    if (!validated.ok) {
+      skip(item.ref, `invalid: ${validated.issues[0]?.message ?? "schema"}`);
+      continue;
+    }
+    const firewall = reviewFirewall(proposal);
+    if (!firewall.allowed) {
+      skip(item.ref, `firewall: ${firewall.issues[0]?.message ?? "rejected"}`);
+      continue;
+    }
+
+    // Does this record supersede anything? A resolved store-resident prior, or a
+    // same-batch predecessor that was actually (predicted-)admitted. A predecessor
+    // that got skipped (firewall/invalid) must NOT count — otherwise dry-run would
+    // report a phantom supersede that apply (which only sees real cells) never does.
+    const supersedesBatch = (item.supersedesTags ?? []).some((t) => admitted.has(t));
+    const willSupersede = priorIds.length > 0 || supersedesBatch;
+
+    if (!apply) {
+      if (willSupersede) {
+        superseded += 1;
+        result.push({ ref: item.ref, action: "supersede", supersedes: priorIds });
+      } else {
+        created += 1;
+        result.push({ ref: item.ref, action: "create" });
+      }
+      admitted.add(item.srcTag);
+      continue;
+    }
+
+    const admission = admitWriteProposal(proposal, store, { derivationKey: item.derivationKey, now: opts.now });
+    if (!admission.accepted || !admission.node) {
+      skip(item.ref, `rejected: ${admission.issues[0]?.message ?? "admission"}`);
+      continue;
+    }
+    admitted.add(item.srcTag);
+    if (priorIds.length > 0) {
+      superseded += 1;
+      result.push({ ref: item.ref, action: "supersede", cellId: admission.node.id, supersedes: priorIds });
+    } else {
+      created += 1;
+      result.push({ ref: item.ref, action: "create", cellId: admission.node.id });
+    }
+  }
+
+  return { source, dryRun: !apply, created, superseded, skipped, items: result };
+}
+
+function uniquePriorIds(store: RecallStore, tags: string[]): string[] {
+  const ids = new Set<string>();
+  for (const tag of tags) {
+    for (const node of store.subgraph({ entities: [tag], limit: MAX_PRIORS })) {
+      ids.add(node.id);
+    }
+  }
+  return [...ids];
+}

--- a/src/core/mem0-adapter.ts
+++ b/src/core/mem0-adapter.ts
@@ -1,0 +1,134 @@
+import { createHash } from "node:crypto";
+import { admitImportItems, clampBody, readImportFile, type ImportItem, type ImportResultItem, type ImportSummary } from "./import-core.js";
+import type { RecallStore } from "./store.js";
+import type { WriteProposal } from "./types.js";
+
+export interface Mem0Memory {
+  id?: string;
+  content: string;
+  categories: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function sha12(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+// Normalize a Mem0 export (get_all / create_memory_export) into memory records.
+// Accepts a top-level array or a {memories|results|data:[...]} envelope. The fact
+// text may live under `memory`, `content`, or `text`; categories at top level or
+// under `metadata.categories`.
+export function parseMem0Export(json: unknown): Mem0Memory[] {
+  return extractRows(json).map((r) => {
+    const rec = (r ?? {}) as Record<string, unknown>;
+    const meta = (rec.metadata ?? {}) as Record<string, unknown>;
+    const cats = asStringArray(rec.categories);
+    return {
+      id: typeof rec.id === "string" ? rec.id : undefined,
+      content: firstString(rec.memory, rec.content, rec.text) ?? "",
+      categories: cats.length > 0 ? cats : asStringArray(meta.categories),
+      createdAt: typeof rec.created_at === "string" ? rec.created_at : undefined,
+      updatedAt: typeof rec.updated_at === "string" ? rec.updated_at : undefined,
+    };
+  });
+}
+
+function extractRows(json: unknown): unknown[] {
+  if (Array.isArray(json)) return json;
+  if (json && typeof json === "object") {
+    const o = json as Record<string, unknown>;
+    for (const key of ["memories", "results", "data"]) {
+      if (Array.isArray(o[key])) return o[key] as unknown[];
+    }
+  }
+  return [];
+}
+
+function firstString(...vals: unknown[]): string | undefined {
+  for (const v of vals) if (typeof v === "string" && v.length > 0) return v;
+  return undefined;
+}
+
+function asStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string" && x.trim() !== "") : [];
+}
+
+function titleFrom(content: string): string {
+  const trimmed = content.trim();
+  const words = trimmed.split(/\s+/);
+  return words.length <= 20 ? trimmed : words.slice(0, 20).join(" ");
+}
+
+function memoryToProposal(mem: Mem0Memory, srcTag: string, project: string, now: string, contradicts: string[]): WriteProposal {
+  const title = titleFrom(mem.content);
+  return {
+    schema_version: "recall.write.v1",
+    actor: { kind: "connector", id: "mem0-adapter", display: "Mem0 adapter" },
+    intent: { kind: "observation", operation: "create" },
+    content: { title, body: clampBody(mem.content), summary: title },
+    scope: { project, tenant: "local" },
+    tags: {
+      category: ["memory"],
+      type: ["observation"],
+      subject: [title],
+      project: [project],
+      idea: ["mem0-import"],
+      timestamp: [(mem.createdAt ?? now).slice(0, 10)],
+      topics: ["mem0", "imported", ...mem.categories],
+      entities: [project, srcTag, ...(mem.id ? [`mem0-id:${mem.id}`] : [])],
+      identities: ["connector:mem0"],
+      rings: ["runtime"],
+      lifecycle: ["active"],
+      quality: ["imported", "source-grounded"],
+    },
+    evidence: { source_refs: [`mem0:${mem.id ?? "unknown"}`], depends_on: [], supports: [], contradicts, concerns: [] },
+    confidence: { value: 0.6, uncertainty: 0.28, concern: 0.12, source_quality: "medium", stability: "stable" },
+    provenance: {
+      created_at: mem.createdAt ?? now,
+      origin: "connector",
+      produced_by: "mem0-adapter",
+      verification: "checked",
+      signature_status: "unsigned",
+    },
+    policy: { sensitivity: "private", allow_background_use: true, requires_review: false, expires_at: null, reverify_after: null },
+  } as WriteProposal;
+}
+
+// Import a Mem0 export file. A missing/unreadable file or invalid JSON is a hard
+// error (the user named the file). A malformed individual record (no id, empty
+// content) is a non-fatal skip-with-reason. Idempotent per memory content; a
+// refined memory (same id, changed content) supersedes its prior version.
+export function importMem0(
+  store: RecallStore,
+  opts: { file: string; project?: string; apply?: boolean; now?: Date }
+): ImportSummary {
+  const json = readImportFile(opts.file, "mem0");
+
+  const project = opts.project ?? "Recall";
+  const now = (opts.now ?? new Date()).toISOString();
+  const preSkips: ImportResultItem[] = [];
+  const items: ImportItem[] = [];
+
+  for (const mem of parseMem0Export(json)) {
+    if (!mem.id) {
+      preSkips.push({ ref: "(no id)", action: "skip", reason: "malformed: missing id" });
+      continue;
+    }
+    if (mem.content.trim().length === 0) {
+      preSkips.push({ ref: mem.id, action: "skip", reason: "empty" });
+      continue;
+    }
+    const srcTag = `mem0-src:${sha12(mem.id)}`;
+    const derivationKey = `mem0:${sha12(mem.id)}:${sha12(mem.content)}`;
+    items.push({
+      ref: mem.id,
+      derivationKey,
+      srcTag,
+      toProposal: (contradicts) => memoryToProposal(mem, srcTag, project, now, contradicts),
+    });
+  }
+
+  const summary = admitImportItems(store, "mem0", items, { apply: opts.apply ?? false, now: opts.now });
+  return { ...summary, skipped: summary.skipped + preSkips.length, items: [...preSkips, ...summary.items] };
+}

--- a/src/core/zep-adapter.ts
+++ b/src/core/zep-adapter.ts
@@ -1,0 +1,185 @@
+import { createHash } from "node:crypto";
+import { admitImportItems, clampBody, readImportFile, type ImportItem, type ImportResultItem, type ImportSummary } from "./import-core.js";
+import type { RecallStore } from "./store.js";
+import type { WriteProposal } from "./types.js";
+
+export interface ZepFact {
+  uuid?: string;
+  fact: string;
+  relation: string;
+  source: string;
+  target: string;
+  validAt?: string;
+  invalidAt?: string;
+  createdAt?: string;
+}
+
+function sha12(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function str(...vals: unknown[]): string | undefined {
+  for (const v of vals) if (typeof v === "string" && v.length > 0) return v;
+  return undefined;
+}
+
+// Normalize a Zep graph export (edges / facts) into bi-temporal fact records.
+// Accepts a top-level array or an {edges|facts|data:[...]} envelope. The relation
+// lives under `name`; invalidation under `invalid_at` or `expired_at`.
+export function parseZepExport(json: unknown): ZepFact[] {
+  return extractRows(json).map((r) => {
+    const rec = (r ?? {}) as Record<string, unknown>;
+    return {
+      uuid: str(rec.uuid, rec.id),
+      fact: str(rec.fact, rec.content) ?? "",
+      relation: str(rec.name, rec.relation, rec.predicate) ?? "",
+      source: str(rec.source_node, rec.source, rec.source_node_name) ?? "",
+      target: str(rec.target_node, rec.target, rec.target_node_name) ?? "",
+      validAt: str(rec.valid_at),
+      invalidAt: str(rec.invalid_at, rec.expired_at),
+      createdAt: str(rec.created_at),
+    };
+  });
+}
+
+function extractRows(json: unknown): unknown[] {
+  if (Array.isArray(json)) return json;
+  if (json && typeof json === "object") {
+    const o = json as Record<string, unknown>;
+    for (const key of ["edges", "facts", "data"]) {
+      if (Array.isArray(o[key])) return o[key] as unknown[];
+    }
+  }
+  return [];
+}
+
+function srcTagFor(uuid: string): string {
+  return `zep-src:${sha12(uuid)}`;
+}
+
+function titleFrom(fact: string): string {
+  const trimmed = fact.trim();
+  const words = trimmed.split(/\s+/);
+  return words.length <= 20 ? trimmed : words.slice(0, 20).join(" ");
+}
+
+function factToProposal(
+  fact: ZepFact,
+  srcTag: string,
+  project: string,
+  now: string,
+  expired: boolean,
+  contradicts: string[]
+): WriteProposal {
+  const title = titleFrom(fact.fact);
+  return {
+    schema_version: "recall.write.v1",
+    actor: { kind: "connector", id: "zep-adapter", display: "Zep adapter" },
+    intent: { kind: "observation", operation: "create" },
+    content: { title, body: clampBody(fact.fact), summary: title },
+    scope: { project, tenant: "local" },
+    tags: {
+      category: ["memory"],
+      type: ["observation"],
+      subject: [title],
+      project: [project],
+      idea: ["zep-import"],
+      timestamp: [(fact.validAt ?? fact.createdAt ?? now).slice(0, 10)],
+      topics: ["zep", "imported", ...(fact.relation ? [fact.relation] : [])],
+      entities: [
+        project,
+        srcTag,
+        ...(fact.source ? [fact.source] : []),
+        ...(fact.target ? [fact.target] : []),
+        ...(fact.uuid ? [`zep-uuid:${fact.uuid}`] : []),
+      ],
+      identities: ["connector:zep"],
+      rings: ["runtime"],
+      lifecycle: [expired ? "expired" : "active"],
+      quality: ["imported", "source-grounded"],
+    },
+    evidence: { source_refs: [`zep:${fact.uuid ?? "unknown"}`], depends_on: [], supports: [], contradicts, concerns: [] },
+    confidence: { value: 0.6, uncertainty: 0.28, concern: 0.12, source_quality: "medium", stability: "stable" },
+    provenance: {
+      created_at: fact.validAt ?? fact.createdAt ?? now,
+      origin: "connector",
+      produced_by: "zep-adapter",
+      verification: "checked",
+      signature_status: "unsigned",
+    },
+    policy: { sensitivity: "private", allow_background_use: true, requires_review: false, expires_at: null, reverify_after: null },
+  } as WriteProposal;
+}
+
+// Import a Zep graph export. Reconstructs Recall supersession from Zep's
+// bi-temporal history: facts are grouped by (source, relation); within a group
+// ordered by valid_at, a fact stamped with invalid_at is superseded by the next
+// fact in the group (a contradicts edge). Co-existing facts (neither invalidated)
+// are NOT chained. A missing/unreadable file or invalid JSON is a hard error;
+// a malformed individual fact is a non-fatal skip.
+//
+// Known limitations (single-snapshot import is the supported path):
+//   - Re-importing across snapshots: a fact already imported as active that later
+//     gains an invalid_at (text unchanged) is skipped as unchanged, so its cell
+//     keeps lifecycle:active — the successor's contradicts edge still carries
+//     currency, but the prior cell's lifecycle tag is not re-stamped.
+//   - An invalidated predecessor with an EMPTY body is dropped before grouping, so
+//     its successor links to nothing (degenerate input).
+export function importZep(
+  store: RecallStore,
+  opts: { file: string; project?: string; apply?: boolean; now?: Date }
+): ImportSummary {
+  const json = readImportFile(opts.file, "zep");
+
+  const project = opts.project ?? "Recall";
+  const now = (opts.now ?? new Date()).toISOString();
+  const preSkips: ImportResultItem[] = [];
+
+  // Group by (source, relation); a superseding fact changes the target, so the
+  // target is NOT part of the grouping key.
+  const groups = new Map<string, ZepFact[]>();
+  for (const fact of parseZepExport(json)) {
+    if (!fact.uuid) {
+      preSkips.push({ ref: "(no uuid)", action: "skip", reason: "malformed: missing uuid" });
+      continue;
+    }
+    if (fact.fact.trim().length === 0) {
+      preSkips.push({ ref: fact.uuid, action: "skip", reason: "empty" });
+      continue;
+    }
+    // JSON-encode the key so distinct (source, relation) pairs can never collide
+    // (e.g. source "A B"/relation "C" vs source "A"/relation "B C").
+    const key = JSON.stringify([fact.source, fact.relation]);
+    (groups.get(key) ?? groups.set(key, []).get(key)!).push(fact);
+  }
+
+  const items: ImportItem[] = [];
+  for (const group of groups.values()) {
+    group.sort(byValidAt);
+    group.forEach((fact, i) => {
+      const srcTag = srcTagFor(fact.uuid!);
+      // A fact supersedes its immediate predecessor iff Zep marked that
+      // predecessor invalid (so co-existing facts are never wrongly chained).
+      const prev = group[i - 1];
+      const supersedesTags = prev && prev.invalidAt ? [srcTagFor(prev.uuid!)] : undefined;
+      const expired = Boolean(fact.invalidAt);
+      items.push({
+        ref: fact.uuid!,
+        derivationKey: `zep:${sha12(fact.uuid!)}:${sha12(fact.fact)}`,
+        srcTag,
+        supersedesTags,
+        toProposal: (contradicts) => factToProposal(fact, srcTag, project, now, expired, contradicts),
+      });
+    });
+  }
+
+  const summary = admitImportItems(store, "zep", items, { apply: opts.apply ?? false, now: opts.now });
+  return { ...summary, skipped: summary.skipped + preSkips.length, items: [...preSkips, ...summary.items] };
+}
+
+function byValidAt(a: ZepFact, b: ZepFact): number {
+  const av = a.validAt ?? a.createdAt ?? "";
+  const bv = b.validAt ?? b.createdAt ?? "";
+  if (av !== bv) return av < bv ? -1 : 1;
+  return (a.uuid ?? "") < (b.uuid ?? "") ? -1 : 1;
+}

--- a/tests/import-core.test.ts
+++ b/tests/import-core.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { admitImportItems, readImportFile, type ImportItem } from "../src/core/import-core.js";
+import { SQLiteRecallStore } from "../src/core/store.js";
+import type { WriteProposal } from "../src/core/types.js";
+import { tempDbPath } from "./helpers.js";
+
+// A minimal valid recall.write.v1 proposal for exercising the import core.
+// The core finds priors to supersede by `subgraph({entities:[srcTag]})`, so each
+// proposal MUST carry its own srcTag in `entities` — that is the contract every
+// adapter (mem0/zep) honors.
+function proposalFor(title: string, body: string, contradicts: string[], srcTag: string): WriteProposal {
+  return {
+    schema_version: "recall.write.v1",
+    actor: { kind: "connector", id: "test-importer", display: "Test importer" },
+    intent: { kind: "observation", operation: "create" },
+    content: { title, body, summary: title },
+    scope: { project: "Test", tenant: "local" },
+    tags: {
+      category: ["memory"],
+      type: ["observation"],
+      subject: [title],
+      project: ["Test"],
+      idea: ["import-core-test"],
+      timestamp: ["2026-06-17"],
+      topics: ["imported", "test"],
+      entities: ["test", srcTag],
+      identities: ["connector:test"],
+      rings: ["runtime"],
+      lifecycle: ["active"],
+      quality: ["imported"],
+    },
+    evidence: { source_refs: ["test"], depends_on: [], supports: [], contradicts, concerns: [] },
+    confidence: { value: 0.6, uncertainty: 0.28, concern: 0.12, source_quality: "medium", stability: "stable" },
+    provenance: {
+      created_at: "2026-06-17T00:00:00.000Z",
+      origin: "connector",
+      produced_by: "test-importer",
+      verification: "checked",
+      signature_status: "unsigned",
+    },
+    policy: { sensitivity: "private", allow_background_use: true, requires_review: false, expires_at: null, reverify_after: null },
+  } as WriteProposal;
+}
+
+function item(opts: {
+  ref: string;
+  body: string;
+  srcTag: string;
+  derivationKey: string;
+  supersedesTags?: string[];
+  title?: string;
+}): ImportItem {
+  return {
+    ref: opts.ref,
+    derivationKey: opts.derivationKey,
+    srcTag: opts.srcTag,
+    supersedesTags: opts.supersedesTags,
+    toProposal: (contradicts) => proposalFor(opts.title ?? opts.ref, opts.body, contradicts, opts.srcTag),
+  };
+}
+
+describe("import core — admitImportItems", () => {
+  it("creates a cell for a fresh item", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = admitImportItems(store, "test", [item({ ref: "a", body: "Alpha", srcTag: "t-src:a", derivationKey: "t:a:1" })], { apply: true });
+      assert.equal(sum.created, 1);
+      assert.equal(sum.superseded, 0);
+      assert.equal(store.listNodes(100).length, 1);
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  it("is idempotent — re-admitting the same derivationKey skips with reason 'unchanged'", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const items = [item({ ref: "a", body: "Alpha", srcTag: "t-src:a", derivationKey: "t:a:1" })];
+      admitImportItems(store, "test", items, { apply: true });
+      const second = admitImportItems(store, "test", items, { apply: true });
+      assert.equal(second.created, 0);
+      assert.equal(second.skipped, 1);
+      assert.equal(second.items[0]!.reason, "unchanged");
+      assert.equal(store.listNodes(100).length, 1);
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  it("supersedes a prior version of the same source unit (same srcTag, new derivationKey)", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const first = admitImportItems(store, "test", [item({ ref: "a", body: "v1", srcTag: "t-src:a", derivationKey: "t:a:1" })], { apply: true });
+      const oldId = first.items[0]!.cellId!;
+      const second = admitImportItems(store, "test", [item({ ref: "a", body: "v2", srcTag: "t-src:a", derivationKey: "t:a:2" })], { apply: true });
+      assert.equal(second.superseded, 1);
+      assert.equal(second.items[0]!.action, "supersede");
+      assert.deepEqual(second.items[0]!.supersedes, [oldId]);
+      const challenges = store.listRelations(oldId, "in", 100).filter((r) => r.kind === "contradicts");
+      assert.equal(challenges.length, 1);
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  it("supersedes a DIFFERENT source unit named in supersedesTags (Zep bi-temporal reconstruction)", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      // A then B, where B supersedes A — both in one batch, in valid_at order.
+      const sum = admitImportItems(
+        store,
+        "zep",
+        [
+          item({ ref: "A", body: "lives in Berlin", srcTag: "z-src:A", derivationKey: "z:A:1" }),
+          item({ ref: "B", body: "lives in Munich", srcTag: "z-src:B", derivationKey: "z:B:1", supersedesTags: ["z-src:A"] }),
+        ],
+        { apply: true }
+      );
+      assert.equal(sum.created, 1, "A created");
+      assert.equal(sum.superseded, 1, "B supersedes A");
+      const aCell = sum.items.find((i) => i.ref === "A")!.cellId!;
+      const challenges = store.listRelations(aCell, "in", 100).filter((r) => r.kind === "contradicts");
+      assert.equal(challenges.length, 1, "A is contradicted by B");
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  it("skips a firewall-tripping item with a reason, in BOTH dry-run and apply (count parity)", () => {
+    const body = "aws key AKIAABCDEFGHIJKLMNOP here"; // trips the AWS-key firewall pattern
+    const mk = () => [item({ ref: "leak", body, srcTag: "t-src:leak", derivationKey: "t:leak:1" })];
+    const a = tempDbPath();
+    const sa = new SQLiteRecallStore(a.path);
+    const b = tempDbPath();
+    const sb = new SQLiteRecallStore(b.path);
+    try {
+      const dry = admitImportItems(sa, "test", mk(), { apply: false });
+      const wet = admitImportItems(sb, "test", mk(), { apply: true });
+      assert.equal(dry.created, wet.created);
+      assert.equal(dry.skipped, wet.skipped);
+      assert.equal(wet.created, 0);
+      assert.match(wet.items[0]!.reason ?? "", /firewall|secret|reject/i);
+    } finally {
+      sa.close();
+      a.cleanup();
+      sb.close();
+      b.cleanup();
+    }
+  });
+
+  it("dry-run reports create/supersede without writing, matching apply counts", () => {
+    const items = [
+      item({ ref: "a", body: "Alpha", srcTag: "t-src:a", derivationKey: "t:a:1" }),
+      item({ ref: "b", body: "Beta", srcTag: "t-src:b", derivationKey: "t:b:1", supersedesTags: ["t-src:a"] }),
+    ];
+    const a = tempDbPath();
+    const sa = new SQLiteRecallStore(a.path);
+    const b = tempDbPath();
+    const sb = new SQLiteRecallStore(b.path);
+    try {
+      const dry = admitImportItems(sa, "test", items, { apply: false });
+      const wet = admitImportItems(sb, "test", items, { apply: true });
+      assert.equal(dry.dryRun, true);
+      assert.equal(sa.listNodes(100).length, 0, "dry-run writes nothing");
+      assert.equal(dry.created, wet.created);
+      assert.equal(dry.superseded, wet.superseded);
+      assert.equal(dry.created, 1);
+      assert.equal(dry.superseded, 1);
+    } finally {
+      sa.close();
+      a.cleanup();
+      sb.close();
+      b.cleanup();
+    }
+  });
+
+  it("dry-run and apply agree when a superseded predecessor is itself skipped (firewall)", () => {
+    // A trips the firewall and is skipped; B names A as predecessor. With A never
+    // admitted, B must be a CREATE in BOTH modes — not a phantom supersede in dry-run.
+    const mk = (): ImportItem[] => [
+      item({ ref: "A", body: "deploy key AKIAABCDEFGHIJKLMNOP", srcTag: "z-src:A", derivationKey: "z:A:1" }),
+      item({ ref: "B", body: "Alice works at Globex", srcTag: "z-src:B", derivationKey: "z:B:1", supersedesTags: ["z-src:A"] }),
+    ];
+    const a = tempDbPath();
+    const sa = new SQLiteRecallStore(a.path);
+    const b = tempDbPath();
+    const sb = new SQLiteRecallStore(b.path);
+    try {
+      const dry = admitImportItems(sa, "zep", mk(), { apply: false });
+      const wet = admitImportItems(sb, "zep", mk(), { apply: true });
+      assert.equal(dry.created, wet.created, "created parity");
+      assert.equal(dry.superseded, wet.superseded, "superseded parity");
+      assert.equal(dry.skipped, wet.skipped, "skipped parity");
+      assert.equal(wet.created, 1, "B is a create — predecessor A was skipped");
+      assert.equal(wet.superseded, 0, "no phantom supersede");
+    } finally {
+      sa.close();
+      a.cleanup();
+      sb.close();
+      b.cleanup();
+    }
+  });
+});
+
+describe("import core — readImportFile", () => {
+  function jsonFile(text: string): { path: string; cleanup: () => void } {
+    const dir = mkdtempSync(join(tmpdir(), "imp-"));
+    const path = join(dir, "x.json");
+    writeFileSync(path, text);
+    return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  }
+
+  it("parses JSON within the size cap", () => {
+    const f = jsonFile(JSON.stringify({ ok: true }));
+    try {
+      assert.deepEqual(readImportFile(f.path, "test", 10_000), { ok: true });
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  it("throws 'too large' when the file exceeds the size cap (no OOM)", () => {
+    const f = jsonFile(JSON.stringify({ some: "content here that exceeds four bytes" }));
+    try {
+      assert.throws(() => readImportFile(f.path, "test", 4), /too large/i);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  it("throws clear errors on a missing file and on invalid JSON", () => {
+    assert.throws(() => readImportFile("/no/such/import-file.json", "test"), /read|file/i);
+    const f = jsonFile("{ not valid json");
+    try {
+      assert.throws(() => readImportFile(f.path, "test"), /json/i);
+    } finally {
+      f.cleanup();
+    }
+  });
+});

--- a/tests/mem0-adapter.test.ts
+++ b/tests/mem0-adapter.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { importMem0, parseMem0Export } from "../src/core/mem0-adapter.js";
+import { SQLiteRecallStore } from "../src/core/store.js";
+import { tempDbPath } from "./helpers.js";
+
+// Write a Mem0 export JSON file and return its path.
+function exportFile(obj: unknown): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "mem0-export-"));
+  const path = join(dir, "mem0.json");
+  writeFileSync(path, JSON.stringify(obj));
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("mem0 adapter — parse", () => {
+  it("parses a top-level array, extracting content and categories", () => {
+    const mems = parseMem0Export([
+      { id: "m1", memory: "User prefers dark mode", categories: ["preferences"], created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    assert.equal(mems.length, 1);
+    assert.equal(mems[0]!.id, "m1");
+    assert.equal(mems[0]!.content, "User prefers dark mode");
+    assert.deepEqual(mems[0]!.categories, ["preferences"]);
+  });
+
+  it("parses the {results:[...]} and {memories:[...]} envelopes and the `content` field", () => {
+    assert.equal(parseMem0Export({ results: [{ id: "a", content: "x" }] })[0]!.content, "x");
+    assert.equal(parseMem0Export({ memories: [{ id: "b", text: "y" }] })[0]!.content, "y");
+  });
+
+  it("reads categories nested under metadata", () => {
+    const mems = parseMem0Export([{ id: "m", memory: "z", metadata: { categories: ["food"] } }]);
+    assert.deepEqual(mems[0]!.categories, ["food"]);
+  });
+
+  it("falls through an empty primary field to a populated fallback field", () => {
+    const mems = parseMem0Export([{ id: "x", memory: "", content: "real content here" }]);
+    assert.equal(mems[0]!.content, "real content here");
+  });
+
+  it("falls back to metadata.categories when top-level categories is not an array", () => {
+    const mems = parseMem0Export([{ id: "x", memory: "z", categories: "food", metadata: { categories: ["real"] } }]);
+    assert.deepEqual(mems[0]!.categories, ["real"]);
+  });
+});
+
+describe("mem0 adapter — import", () => {
+  it("dry-runs: reports created, writes nothing", () => {
+    const f = exportFile([{ id: "m1", memory: "Alpha fact" }, { id: "m2", memory: "Beta fact" }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importMem0(store, { file: f.path, apply: false });
+      assert.equal(sum.source, "mem0");
+      assert.equal(sum.dryRun, true);
+      assert.equal(sum.created, 2);
+      assert.equal(store.listNodes(100).length, 0);
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("apply imports each memory as a cell (title from content, body = content)", () => {
+    const f = exportFile([{ id: "m1", memory: "The deploy uses blue-green rollout" }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importMem0(store, { file: f.path, apply: true });
+      assert.equal(sum.created, 1);
+      const nodes = store.listNodes(100);
+      assert.equal(nodes.length, 1);
+      assert.match(nodes[0]!.title, /deploy uses blue-green/);
+      assert.match(nodes[0]!.body, /blue-green rollout/);
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("is idempotent — re-importing the same export skips every memory", () => {
+    const f = exportFile([{ id: "m1", memory: "stable fact" }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      importMem0(store, { file: f.path, apply: true });
+      const second = importMem0(store, { file: f.path, apply: true });
+      assert.equal(second.created, 0);
+      assert.equal(second.skipped, 1);
+      assert.equal(store.listNodes(100).length, 1);
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("supersedes when a memory's content changes (same id, refined memory)", () => {
+    const v1 = exportFile([{ id: "m1", memory: "Postgres pool capped at 20" }]);
+    const v2 = exportFile([{ id: "m1", memory: "Postgres pool capped at 50" }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const first = importMem0(store, { file: v1.path, apply: true });
+      const oldId = first.items[0]!.cellId!;
+      const second = importMem0(store, { file: v2.path, apply: true });
+      assert.equal(second.superseded, 1);
+      assert.equal(second.items[0]!.action, "supersede");
+      const challenges = store.listRelations(oldId, "in", 100).filter((r) => r.kind === "contradicts");
+      assert.equal(challenges.length, 1);
+    } finally {
+      store.close();
+      temp.cleanup();
+      v1.cleanup();
+      v2.cleanup();
+    }
+  });
+
+  it("skips a memory whose content trips the secret firewall", () => {
+    const f = exportFile([{ id: "ok", memory: "harmless fact" }, { id: "leak", memory: "aws key AKIAABCDEFGHIJKLMNOP" }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importMem0(store, { file: f.path, apply: true });
+      assert.equal(sum.created, 1);
+      assert.equal(sum.skipped, 1);
+      const leak = sum.items.find((i) => i.ref === "leak")!;
+      assert.equal(leak.action, "skip");
+      assert.match(leak.reason ?? "", /firewall|secret/i);
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("skips a malformed record (missing id or empty content) without failing the import", () => {
+    const f = exportFile([{ id: "good", memory: "real" }, { memory: "no id" }, { id: "empty", memory: "   " }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importMem0(store, { file: f.path, apply: true });
+      assert.equal(sum.created, 1);
+      assert.equal(sum.skipped, 2);
+      assert.equal(store.listNodes(100).length, 1);
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("throws a clear error when the export file is missing", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      assert.throws(() => importMem0(store, { file: "/no/such/mem0-export.json", apply: false }), /mem0|file|not found|read/i);
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+
+  it("clamps an oversized memory body instead of storing megabytes", () => {
+    const f = exportFile([{ id: "big", memory: "x".repeat(40_000) }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      importMem0(store, { file: f.path, apply: true });
+      const node = store.listNodes(100)[0]!;
+      assert.ok(node.body.length <= 32_768, `body clamped (${node.body.length})`);
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("imports a memory even when one of its categories is an empty string", () => {
+    const f = exportFile([{ id: "x", memory: "good memory", categories: ["", "ok"] }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importMem0(store, { file: f.path, apply: true });
+      assert.equal(sum.created, 1);
+      assert.equal(store.listNodes(100).length, 1);
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+});
+
+const CLI = ["--disable-warning=ExperimentalWarning", "dist/src/cli.js"];
+
+describe("cli import mem0", () => {
+  it("dry-runs by default and imports with --apply", () => {
+    const f = exportFile([{ id: "m1", memory: "cli imported fact" }]);
+    const temp = tempDbPath();
+    try {
+      const dry = execFileSync(process.execPath, [...CLI, "import", "mem0", "--file", f.path, "--db", temp.path], { encoding: "utf8" });
+      assert.match(dry, /"dryRun": true/);
+      assert.match(dry, /"created": 1/);
+      const applied = execFileSync(process.execPath, [...CLI, "import", "mem0", "--file", f.path, "--apply", "--db", temp.path], { encoding: "utf8" });
+      assert.match(applied, /"created": 1/);
+      const store = new SQLiteRecallStore(temp.path);
+      assert.equal(store.listNodes(100).length, 1);
+      store.close();
+    } finally {
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("prints a clean error (no raw stack trace) and exits non-zero when the file is missing", () => {
+    const temp = tempDbPath();
+    try {
+      let err: { status?: number; stdout?: string; stderr?: string } | undefined;
+      try {
+        execFileSync(process.execPath, [...CLI, "import", "mem0", "--file", "/no/such/x.json", "--db", temp.path], { encoding: "utf8", stdio: "pipe" });
+      } catch (e) {
+        err = e as { status?: number; stdout?: string; stderr?: string };
+      }
+      assert.ok(err, "exits non-zero");
+      const out = `${err!.stdout ?? ""}${err!.stderr ?? ""}`;
+      assert.match(out, /cannot read|mem0 import/i, "clean message");
+      assert.doesNotMatch(out, /\bat \S+ \(|\.ts:\d+:\d+\)/, "no raw stack trace");
+    } finally {
+      temp.cleanup();
+    }
+  });
+});

--- a/tests/zep-adapter.test.ts
+++ b/tests/zep-adapter.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { importZep, parseZepExport } from "../src/core/zep-adapter.js";
+import { SQLiteRecallStore } from "../src/core/store.js";
+import { tempDbPath } from "./helpers.js";
+
+function exportFile(obj: unknown): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "zep-export-"));
+  const path = join(dir, "zep.json");
+  writeFileSync(path, JSON.stringify(obj));
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("zep adapter — parse", () => {
+  it("normalizes edge fields (uuid/fact/name→relation/source_node/target_node/valid_at)", () => {
+    const facts = parseZepExport({
+      edges: [{ uuid: "e1", fact: "Alice works at Acme", name: "WORKS_AT", source_node: "Alice", target_node: "Acme", valid_at: "2025-01-01T00:00:00Z" }],
+    });
+    assert.equal(facts.length, 1);
+    assert.equal(facts[0]!.uuid, "e1");
+    assert.equal(facts[0]!.fact, "Alice works at Acme");
+    assert.equal(facts[0]!.relation, "WORKS_AT");
+    assert.equal(facts[0]!.source, "Alice");
+    assert.equal(facts[0]!.target, "Acme");
+    assert.equal(facts[0]!.validAt, "2025-01-01T00:00:00Z");
+  });
+
+  it("accepts the {facts:[...]} envelope and a top-level array, with id/expired_at fallbacks", () => {
+    assert.equal(parseZepExport({ facts: [{ id: "f", fact: "x", relation: "R", source: "A", target: "B" }] })[0]!.uuid, "f");
+    assert.equal(parseZepExport([{ uuid: "g", fact: "y", name: "R", source: "A", target: "B", expired_at: "2025-06-01" }])[0]!.invalidAt, "2025-06-01");
+  });
+});
+
+describe("zep adapter — import", () => {
+  it("apply imports each fact as a cell", () => {
+    const f = exportFile([{ uuid: "f1", fact: "Cache TTL is 60 seconds", name: "HAS_TTL", source: "Cache", target: "60s" }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importZep(store, { file: f.path, apply: true });
+      assert.equal(sum.source, "zep");
+      assert.equal(sum.created, 1);
+      assert.match(store.listNodes(100)[0]!.title, /Cache TTL is 60 seconds/);
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("reconstructs supersession from bi-temporal history (invalidated fact ← superseding fact)", () => {
+    // Same (source, relation), target changed; the old fact carries invalid_at.
+    // Deliberately listed out of valid_at order to exercise sorting.
+    const f = exportFile([
+      { uuid: "newer", fact: "Alice works at Globex", name: "WORKS_AT", source: "Alice", target: "Globex", valid_at: "2025-06-01T00:00:00Z" },
+      { uuid: "older", fact: "Alice works at Acme", name: "WORKS_AT", source: "Alice", target: "Acme", valid_at: "2025-01-01T00:00:00Z", invalid_at: "2025-06-01T00:00:00Z" },
+    ]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importZep(store, { file: f.path, apply: true });
+      assert.equal(sum.created, 1, "the older fact is created");
+      assert.equal(sum.superseded, 1, "the newer fact supersedes the older");
+      const olderCell = sum.items.find((i) => i.ref === "older")!.cellId!;
+      const challenges = store.listRelations(olderCell, "in", 100).filter((r) => r.kind === "contradicts");
+      assert.equal(challenges.length, 1, "the older fact is contradicted by the newer one");
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("does NOT chain co-existing facts (same source+relation, neither invalidated)", () => {
+    const f = exportFile([
+      { uuid: "k1", fact: "Alice knows Bob", name: "KNOWS", source: "Alice", target: "Bob", valid_at: "2025-01-01T00:00:00Z" },
+      { uuid: "k2", fact: "Alice knows Carol", name: "KNOWS", source: "Alice", target: "Carol", valid_at: "2025-02-01T00:00:00Z" },
+    ]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importZep(store, { file: f.path, apply: true });
+      assert.equal(sum.created, 2, "both facts are independent creates");
+      assert.equal(sum.superseded, 0, "no wrongful supersession");
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("does not collide distinct (source, relation) pairs in the grouping key", () => {
+    // "A B" / "C" and "A" / "B C" both space-join to "A B C" — they must NOT chain.
+    const f = exportFile([
+      { uuid: "p", fact: "old colliding fact", name: "C", source: "A B", target: "T1", valid_at: "2025-01-01T00:00:00Z", invalid_at: "2025-02-01T00:00:00Z" },
+      { uuid: "q", fact: "unrelated fact", name: "B C", source: "A", target: "T2", valid_at: "2025-03-01T00:00:00Z" },
+    ]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importZep(store, { file: f.path, apply: true });
+      assert.equal(sum.created, 2, "distinct pairs are independent");
+      assert.equal(sum.superseded, 0, "no spurious supersession from a key collision");
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("is idempotent across re-imports", () => {
+    const f = exportFile([{ uuid: "f1", fact: "stable fact", name: "R", source: "A", target: "B" }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      importZep(store, { file: f.path, apply: true });
+      const second = importZep(store, { file: f.path, apply: true });
+      assert.equal(second.created, 0);
+      assert.equal(second.skipped, 1);
+      assert.equal(store.listNodes(100).length, 1);
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("skips a fact whose text trips the secret firewall", () => {
+    const f = exportFile([{ uuid: "leak", fact: "token is AKIAABCDEFGHIJKLMNOP", name: "HAS_TOKEN", source: "svc", target: "key" }]);
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      const sum = importZep(store, { file: f.path, apply: true });
+      assert.equal(sum.created, 0);
+      assert.equal(sum.skipped, 1);
+      assert.match(sum.items[0]!.reason ?? "", /firewall|secret/i);
+    } finally {
+      store.close();
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+
+  it("throws a clear error when the export file is missing", () => {
+    const temp = tempDbPath();
+    const store = new SQLiteRecallStore(temp.path);
+    try {
+      assert.throws(() => importZep(store, { file: "/no/such/zep.json", apply: false }), /zep|file|not found|read/i);
+    } finally {
+      store.close();
+      temp.cleanup();
+    }
+  });
+});
+
+const CLI = ["--disable-warning=ExperimentalWarning", "dist/src/cli.js"];
+
+describe("cli import zep", () => {
+  it("dry-runs by default and imports with --apply", () => {
+    const f = exportFile([{ uuid: "z1", fact: "cli zep fact", name: "R", source: "A", target: "B" }]);
+    const temp = tempDbPath();
+    try {
+      const dry = execFileSync(process.execPath, [...CLI, "import", "zep", "--file", f.path, "--db", temp.path], { encoding: "utf8" });
+      assert.match(dry, /"dryRun": true/);
+      assert.match(dry, /"created": 1/);
+      const applied = execFileSync(process.execPath, [...CLI, "import", "zep", "--file", f.path, "--apply", "--db", temp.path], { encoding: "utf8" });
+      assert.match(applied, /"created": 1/);
+      const store = new SQLiteRecallStore(temp.path);
+      assert.equal(store.listNodes(100).length, 1);
+      store.close();
+    } finally {
+      temp.cleanup();
+      f.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## What

`recall import mem0|zep --file <export.json>`, the migration wedge, increment 2. Import a **Mem0** export (`get_all` / `create_memory_export`) or a **Zep** graph export into Recall as calibrated cells. Dry-run by default; `--apply` writes. *Own your memory, cancel the subscription.*

```
recall import mem0 --file mem0-export.json            # preview
recall import mem0 --file mem0-export.json --apply     # write
recall import zep  --file zep-export.json  --apply
```

## How

The shipped `auto-memory-adapter.ts` is **untouched**. The two new importers share a new spine:

- **`src/core/import-core.ts`**, `admitImportItems`: dedup by `derivationKey`, predict `validate + firewall` so **dry-run counts match apply**, supersede priors found by a stable `srcTag`, cross-item supersession via `supersedesTags`, skip-with-reason. Plus `readImportFile` (size-capped read+parse) and `clampBody`.
- **`src/core/mem0-adapter.ts`**, flat memories → cells; a *refined* memory (same id, changed content) supersedes its prior version.
- **`src/core/zep-adapter.ts`**, the differentiator: reconstructs Recall supersession from Zep's **bi-temporal history**. Facts are grouped by `(source, relation)`, and a fact stamped `invalid_at` is superseded by the next fact in its group (a `contradicts` edge). Co-existing facts ("knows Bob" + "knows Carol") are **not** chained. Pull-memory history → push-memory supersession.

## Hardened per a 3-lens adversarial review (11 findings, all triaged)

| Fixed | |
|---|---|
| **dry-run/apply parity** holds even when a superseded predecessor is itself skipped (firewall/invalid), no phantom supersede | high |
| **128 MB file-size cap** before read (no OOM); **per-record body clamp** bounds storage + the firewall regex scan | high/med |
| mem0 field/category fallbacks no longer drop a record on an empty primary field or empty category | med/low |
| Zep grouping key can't collide distinct `(source,relation)` pairs | low |
| file errors route through `fail()` (clean message, no stack trace) | low |

Two findings deferred **with a documented limitation** (cross-snapshot lifecycle re-stamp; an invalidated predecessor with an empty body), the suggested fix for the first creates duplicate cells, worse than the cosmetic issue; the contradicts edge already carries currency.

## Tests

- **36 adapter tests** (import-core 9, mem0 14, zep 13), incl. a regression test for every accepted finding.
- Full suite **198/198** · e2e **94**.
- Live CLI smoke: a Zep bi-temporal pair imports so `recall beliefs` flags the superseded fact (`"Alice works at Globex contradicts this cell"`).