### PR TITLE
docs: tighten punctuation and phrasing

### DIFF
--- a/.github/assets/recall-architecture.svg
+++ b/.github/assets/recall-architecture.svg
@@ -1,5 +1,5 @@
 <svg width="1280" height="520" viewBox="0 0 1280 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Recall architecture: the write, admit, store, compile loop">
-  <title>Recall architecture — the write / admit / store / compile loop</title>
+  <title>Recall architecture: the write / admit / store / compile loop</title>
   <defs>
     <linearGradient id="ar-accent" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#2dd4bf"/>
@@ -72,7 +72,7 @@
 
   <!-- compiled packet return arrow -->
   <path d="M1060 288 V360 H138 V276" fill="none" stroke="#2dd4bf" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#ar-arrow-accent)"/>
-  <text x="600" y="352" text-anchor="middle" font-family="-apple-system, system-ui, sans-serif" font-size="13" fill="#5eead4">compiled context packet returns to the model — never the whole store</text>
+  <text x="600" y="352" text-anchor="middle" font-family="-apple-system, system-ui, sans-serif" font-size="13" fill="#5eead4">compiled context packet returns to the model, never the whole store</text>
 
   <!-- Daemon -->
   <g transform="translate(312, 408)">

--- a/.github/assets/recall-banner-dark.svg
+++ b/.github/assets/recall-banner-dark.svg
@@ -1,5 +1,5 @@
-<svg width="1280" height="360" viewBox="0 0 1280 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Recall — push memory for AI agents">
-  <title>Recall — push memory for AI agents</title>
+<svg width="1280" height="360" viewBox="0 0 1280 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Recall: push memory for AI agents">
+  <title>Recall: push memory for AI agents</title>
   <defs>
     <linearGradient id="bd-accent" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#2dd4bf"/>

--- a/.github/assets/recall-banner-light.svg
+++ b/.github/assets/recall-banner-light.svg
@@ -1,5 +1,5 @@
-<svg width="1280" height="360" viewBox="0 0 1280 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Recall — push memory for AI agents">
-  <title>Recall — push memory for AI agents</title>
+<svg width="1280" height="360" viewBox="0 0 1280 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Recall: push memory for AI agents">
+  <title>Recall: push memory for AI agents</title>
   <defs>
     <linearGradient id="bl-accent" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#0d9488"/>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,11 +51,11 @@ beliefs, tasks, risks, decisions, contradictions, programs, and provenance
 outside the LLM context window. The LLM receives only compiled, task-specific
 context packets.
 
-**Recall is your durable memory — use it, not scratch files or note memory.** A
+**Recall is your durable memory: use it, not scratch files or note memory.** A
 durable fact written anywhere but Recall is invisible to the conflict and
 effective-confidence machinery and goes silently stale. And when you learn
 something that **corrects or invalidates** an earlier fact, do not overwrite it
-or add an unlinked duplicate — **supersede it**: admit the new cell with
+or add an unlinked duplicate; **supersede it** by admitting the new cell with
 `evidence.contradicts` pointing at the prior cell id. Recall then demotes the
 old cell and marks it challenged, so every future session sees the current
 answer *and* that the old one was overruled. Superseding is the line between
@@ -104,7 +104,7 @@ The loop is **compile → work → write back**:
    existing fact, first `recall_search` for the prior cell, then admit the new
    one with `evidence.contradicts: ["<prior-cell-id>"]`. A correction without
    that link leaves two competing cells and no resolution.
-5. Never claim memory was saved if the write was rejected — confirm the
+5. Never claim memory was saved if the write was rejected; confirm the
    `accepted: true` cell id before reporting it as stored.
 
 Full contract, proposal shape, and tag families:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   primary graph and were searchable. The pattern set now covers these common
   secret shapes (verified by new tests), while still passing benign prose that
   merely mentions security words. The skill docs and README now describe the
-  firewall honestly as a **high-recall heuristic backstop, not a guarantee** —
-  real secrets still belong in the encrypted side graph.
+  firewall honestly as a high-recall heuristic backstop, not a guarantee.
+  Real secrets still belong in the encrypted side graph.
 
 ### Fixed
 
@@ -46,11 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Codex integration** (`recall codex sync` / `recall codex status`,
   `src/core/codex-integration.ts`, `integrations/codex/`): idempotently wires
   Recall into the OpenAI Codex CLI to the same standard as the Claude Code
-  integration — installs the recall skill into `~/.codex/skills/recall/`,
+  integration: installs the recall skill into `~/.codex/skills/recall/`,
   registers the `[mcp_servers.recall]` server in `~/.codex/config.toml` (a pure,
   unit-tested TOML upsert that preserves other servers/config), and injects a
   marker-delimited Recall directive into `~/.codex/AGENTS.md` (Codex's
-  always-read global instruction surface — the analog of Claude's SessionStart
+  always-read global instruction surface, the analog of Claude's SessionStart
   hook). Codex exposes no single native-memory kill switch, so displacement is
   prompt-level via the AGENTS.md directive. `scripts/install.sh` and
   `scripts/install-local.sh` run `recall codex sync` (fail-soft) when the Codex
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   auto-memory (the flat `MEMORY.md` index + per-fact `.md` store). Models
   auto-memory faithfully (real nested-frontmatter format, overwrite-in-place on
   correction) and drives Recall via the repo's own built CLI on an isolated
-  `--db`. Eight scenarios (B1–B8): ties on the basics (persist/recall, correction
+  `--db`. Eight scenarios (B1 to B8): ties on the basics (persist/recall, correction
   reaches current value), Recall wins on supersession audit trail,
   cross-session resolution inheritance, structured confidence/provenance, and
   bounded context cost at scale; auto-memory is cheaper at small store sizes
@@ -79,8 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [--db path]`): imports Claude Code auto-memory files
   (`~/.claude/projects/<slug>/memory/*.md`) into Recall as calibrated cells.
   Dry-run by default; `--apply` writes. Idempotent per file content; a changed
-  file supersedes its prior version via a `contradicts` edge — the migration
-  wedge for owning your memory and canceling the subscription.
+  file supersedes its prior version via a `contradicts` edge. This is the
+  migration path for owning your memory and canceling the subscription.
 - **`recall repair`** (`[--apply] [--db path]`): prunes dangling/unresolvable
   trust edges; dry-run by default, `--apply` deletes.
 
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surface and 162-test suite.
 - **Claude Code hook** (`integrations/claude/hooks/recall-session-start.py`): the
   SessionStart activity summary no longer mislabels a graph-wide diff as "scoped
-  to this directory" — the scope is now derived from `recall project where` and
+  to this directory"; the scope is now derived from `recall project where` and
   labelled accurately (`graph-wide (global memory)` vs `scoped to project '<x>'`).
   The hook now also gates the diff on a clean subprocess exit, so a failed diff
   that prints partial/garbage text to stdout can never be injected into model
@@ -255,7 +255,7 @@ memory.
   (point-in-time score) and `python/hooks/longitudinal_tracker.py`
   (snapshot + trajectory analysis: rationale quality, rework rate,
   enforcement events, continuity value).
-- Comprehensive test suites: `python/hooks/test_hooks.py` (hook +
+- Test suites: `python/hooks/test_hooks.py` (hook +
   tracker + adapter tests), `python/tests/system_tests.py` (10
   stress + 10 capability tests), `python/tests/competitive_tests.py`
   (head-to-head matrix vs 6 competitor memory architectures).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br/>
 <br/>
 
-**The memory layer your agent just uses — it remembers, corrects itself, and recalls across sessions on its own. Local, free, and yours.**
+**The memory layer your agent just uses. It remembers, corrects itself, and recalls across sessions on its own. Local, free, and yours.**
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-0d9488.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%E2%89%A524-0d9488.svg)](package.json)
@@ -38,13 +38,13 @@
 
 **Most agent memory is _pull_: a store you query.** You ask, it returns the
 closest matches, and it is on you to notice when a fact has gone stale. Recall
-is _push_: the agent and the substrate run a loop together — it checks what it
+is _push_: the agent and the substrate run a loop together. It checks what it
 already knows before it acts, does the work, and writes back what it learned,
 _superseding_ the old fact when something changes and surfacing the
 contradiction without being asked. No reminding it to save, no separate cloud
 service mining your transcript after the fact. Under the hood an LLM proposes a
 structured write, an admission firewall validates it, and the compiler returns
-only the relevant subgraph — ranked by evidence, fit to a word budget — all in
+only the relevant subgraph, ranked by evidence, fit to a word budget, all in
 local SQLite: no server, no account, no cloud. The memory is yours, and every
 fact still carries provenance, confidence, and a one-command undo.
 
@@ -72,7 +72,7 @@ readiness lane for MCP smoke, Python hooks/toolkit checks, public benchmarks,
 and installer validation. Upgrades, uninstall, and troubleshooting:
 [Installation Guide](docs/11_INSTALLATION.md).
 
-### Put your agent on Recall — one command
+### Put your agent on Recall in one command
 
 The installer above already wires up any agent CLI it finds. To do it yourself
 (or after installing a new agent), one idempotent command sets up the skill, the
@@ -84,7 +84,7 @@ recall codex sync      # OpenAI Codex:  skill + MCP in config.toml + a Recall di
 recall claude status   # confirm what's wired   (recall codex status for Codex)
 ```
 
-Restart your agent and it's **armed** — it reads memory before relying on
+Restart your agent and it's armed: it reads memory before relying on
 recollection and writes durable findings back on its own; you never tell it to
 "save." Both syncs back up your config before editing, are safe to re-run, and
 are reversible (`recall claude enable-auto-memory`). Using a different MCP
@@ -194,45 +194,45 @@ restore path, including file-level SQLite copies and upgrade safety.
 **Change your mind without losing the past.** Recall's moat is supersession: a
 correction is never an overwrite. You admit a new cell that `--contradicts` the
 old one, and every future read *demotes* the superseded value instead of deleting
-it — the conflict resolves automatically, at read time.
+it; the conflict resolves automatically, at read time.
 
-[![Recall supersession — the old value is preserved-but-demoted, resolved at read time](assets/recall-supersede-demo-poster.png)](assets/recall-supersede-demo.mp4)
+[![Recall supersession: the old value is preserved-but-demoted, resolved at read time](assets/recall-supersede-demo-poster.png)](assets/recall-supersede-demo.mp4)
 
 ▶ Click the frame (or open [`assets/recall-supersede-demo.mp4`](assets/recall-supersede-demo.mp4))
-for a ~17s screencast — a **real, unedited `recall` run**:
+for a ~17s screencast, a real, unedited `recall` run:
 
-- **`v1`** — *"Cache TTL is 60s"* lands at full strength (`eff:0.70`).
-- **`v2 --contradicts v1`** — *"…is 300s."* Read it back and `compile` doesn't
+- **`v1`**: *"Cache TTL is 60s"* lands at full strength (`eff:0.70`).
+- **`v2 --contradicts v1`**: *"…is 300s."* Read it back and `compile` doesn't
   return both as equals: `v1` is demoted to `eff:0.29(challenged)`, `v2` stays
-  high. The old value is **still in the graph** — preserved, queryable, just
+  high. The old value is still in the graph: preserved, queryable, just
   down-weighted.
-- **`v3 --contradicts v2`** — a 3-link chain. `v1` and `v2` collapse to `eff:0`;
+- **`v3 --contradicts v2`**: a 3-link chain. `v1` and `v2` collapse to `eff:0`;
   exactly one live answer remains, the *why-we-changed* trail intact.
-- The run asserts a tripwire — the real graph was untouched (`334 → 334`, a
+- The run asserts a tripwire: the real graph was untouched (`334 → 334`, a
   throwaway db).
 
 Demotion-not-deletion is the line between memory that merely *persists* and
-memory that stays *honest* — the whole point of Recall over a flat note file.
+memory that stays *honest*, the whole point of Recall over a flat note file.
 
 ### See it all working
 
-Every Recall capability has a short, honest screencast — real CLI, real output,
-an isolated graph — with the **full script and the unedited transcript** beside
-each clip. Browse them all in the **[companion gallery](https://h-xx-d.github.io/recall-demos/)**.
+Every Recall capability has a short, honest screencast: real CLI, real output,
+an isolated graph, with the full script and the unedited transcript beside
+each clip. Browse them all in the [companion gallery](https://h-xx-d.github.io/recall-demos/).
 
 | Screencast | What it shows |
 |---|---|
 | **Install in one command** | `recall claude sync` / `recall codex sync` wires the skill, MCP, and consult-Recall hook, and turns off native note-memory |
-| **[Autonomous memory across sessions](assets/recall-claude-demo.mp4)** | three `claude` sessions, natural prompts, nobody says "save" — persist → supersede → cold-session recall |
+| **[Autonomous memory across sessions](assets/recall-claude-demo.mp4)** | three `claude` sessions, natural prompts, nobody says "save"; persist → supersede → cold-session recall |
 | **Supersession mechanics** *(the clip above)* | the `contradicts` edge, read-time demotion, multi-link chains |
-| **Rollback a write** | journaled, reversible undo — archives the node, strips its relations |
+| **Rollback a write** | journaled, reversible undo; archives the node, strips its relations |
 | **Inception** | grounded idea synthesis: a new hypothesis pre-linked (`depends_on`) to its sources |
 | **Effective confidence** | stated vs graph-computed trust, recomputed on every read |
-| **Compile** | ids-first context packets — expand a cell or single field only when needed |
+| **Compile** | ids-first context packets; expand a cell or single field only when needed |
 | **Retrieval** | FTS5 + BM25 with porter stemming and identifier-aware tokenization |
 | **Subgraph** | slice the graph by structured facets (tags), not just search |
 | **Memory health** | `recall beliefs` / `recall maintenance --derive` audits between turns |
-| **Calibration** | per-actor Brier scores — memory that learns who to trust |
+| **Calibration** | per-actor Brier scores; memory that learns who to trust |
 | **Watch programs** | a non-LLM monitor that trips when the graph turns against a belief |
 | **Secrets** | firewall refuses credential shapes; real secrets go in the encrypted side graph |
 | **Diff-aware resume** | what's new, updated, and retracted since you left |
@@ -311,13 +311,13 @@ Already accumulated native auto-memory? `recall import auto-memory [--root path]
 [--project name] [--apply] [--db path]` imports your
 `~/.claude/projects/<slug>/memory/*.md` files into Recall as calibrated cells
 (dry-run by default; pass `--apply` to write). It is idempotent per file content,
-and a changed file supersedes its prior version via a `contradicts` edge — the
+and a changed file supersedes its prior version via a `contradicts` edge, the
 migration wedge for owning your memory.
 
 **Codex** (`recall codex sync`) copies the recall skill into
 `~/.codex/skills/`, registers the recall MCP server under `[mcp_servers.recall]`
 in `~/.codex/config.toml`, and injects a marker-delimited Recall directive into
-`~/.codex/AGENTS.md` — Codex's always-read global instructions, the analog of
+`~/.codex/AGENTS.md`, Codex's always-read global instructions, the analog of
 Claude Code's SessionStart hook. Codex exposes no native-memory kill switch, so
 Recall is positioned as the durable memory layer at the prompt level via that
 directive. All edits are backed up before write, preserve your existing config,
@@ -606,8 +606,8 @@ the code, Solver computes, Recall remembers, Checker attests.
 **Lattice** is the code-analysis layer, and the one part that is an
 enterprise capability rather than open source: access-gated, vetted, and
 not bundled in the OSS distribution. It ingests a codebase over the
-Language Server Protocol into the same typed hypernetwork Recall uses —
-symbols, modules, and the import, call, and reference edges between them —
+Language Server Protocol into the same typed hypernetwork Recall uses
+(symbols, modules, and the import, call, and reference edges between them),
 then runs structural analyses over that graph. `impact` returns a change's
 reverse-reachability blast radius *before* you edit; `hunt` ranks
 structural bugs, including cross-signal findings no single diagnostic
@@ -623,15 +623,15 @@ Checker enforces: reachability tells you where to look, never that a bug
 is proven.
 
 What sets it apart is where the findings go. Lattice grounds everything it
-computes: the hard combinatorial step — the minimum feedback arc set that
-breaks a dependency cycle — routes to Solver's gated QUBO tier and is
+computes: the hard combinatorial step (the minimum feedback arc set that
+breaks a dependency cycle) routes to Solver's gated QUBO tier and is
 verified locally before it is trusted, and results land in Recall as
 addressable, evidence-weighted cells through the same admission gate as
 every other write. A structural regression stops being a console warning
 that scrolls away and becomes a cell with provenance that a deploy gate
 can score and a teammate can compile tomorrow. It ships an MCP server
-built for the agent edit loop — ask `impact` before an edit, gate with
-`hunt` after — served in milliseconds off a graph ingested once and
+built for the agent edit loop (ask `impact` before an edit, gate with
+`hunt` after), served in milliseconds off a graph ingested once and
 cached.
 
 Together they cover memory, verification, computation, and code structure

--- a/docs/05_CLI_TUI.md
+++ b/docs/05_CLI_TUI.md
@@ -66,10 +66,10 @@ recall daemon uninstall
 `recall import auto-memory` imports Claude Code auto-memory files
 (`~/.claude/projects/<slug>/memory/*.md`) into Recall as calibrated cells. It is
 dry-run by default; `--apply` writes. It is idempotent per file content, and a
-changed file supersedes its prior version via a `contradicts` edge — the
-migration wedge for owning your memory. `recall repair` prunes
+changed file supersedes its prior version via a `contradicts` edge. This is the
+migration path for owning your memory. `recall repair` prunes
 dangling/unresolvable trust edges (dry-run by default; `--apply` deletes), and
-`recall calibration` reports per-actor Brier calibration — stated confidence
+`recall calibration` reports per-actor Brier calibration: stated confidence
 versus contradiction outcomes.
 
 Routine memory writes are not a user workflow. Once Recall is running, the LLM

--- a/docs/10_SENTINEL_BENCHMARK.md
+++ b/docs/10_SENTINEL_BENCHMARK.md
@@ -1,13 +1,13 @@
-# 10 · SENTINEL — the Unprompted-Contradiction Benchmark
+# 10 · SENTINEL: the Unprompted-Contradiction Benchmark
 
 **Thesis.** Every shipping memory benchmark (LoCoMo, LongMemEval, …) tests
 *read accuracy*: given history, answer a query. They are **pull** tests, and the
-systems built for them (Mem0, Zep, Letta, LangMem) are pull architectures —
+systems built for them (Mem0, Zep, Letta, LangMem) are pull architectures:
 information flows only in response to a question.
 
 SENTINEL is a **push** test. It measures whether a memory system, as new
 information arrives over time, **autonomously surfaces that a newly-stored fact
-invalidates a previously-held belief — without being asked**. That is the
+invalidates a previously-held belief, without being asked**. That is the
 reliability-floor-over-time capability: a model-independent invariant, not
 model-dependent navigation.
 
@@ -19,18 +19,18 @@ A pull system has no place to emit a signal nobody queried for. To score on
 SENTINEL at all, a system needs a **write-time evaluation hook** that runs on
 admission and can re-price/flag prior beliefs. Recall has this natively (reflex
 programs `watch`/`drift`/`score` + contradiction-on-admission + effective-
-confidence demotion). Mem0/Zep/Letta do not, so they score **0 by construction**
-— not because they're weak, but because the capability is outside their shape.
+confidence demotion). Mem0/Zep/Letta do not, so they score **0 by construction**,
+not because they're weak, but because the capability is outside their shape.
 
 **Fairness guardrails (so it isn't a strawman):**
-1. The capability is *independently valuable* — silently serving a stale fact is
+1. The capability is *independently valuable*: silently serving a stale fact is
    a top production failure mode; users need to be told "the thing you believed
    changed" without re-auditing.
 2. Anyone can compete by bolting on a hook. SENTINEL provides the **fair bolt-on
-   baseline**: re-query every prior belief after each write. It can score — at
+   baseline**: re-query every prior belief after each write. It can score, at
    **O(beliefs × writes)** cost. Detection *and* cost are reported, so
    "native vs bolted-on" is an honest axis.
-3. **Precision is scored** — a system that flags everything is useless and loses.
+3. **Precision is scored**: a system that flags everything is useless and loses.
 
 ## Task & metrics
 
@@ -40,23 +40,23 @@ Input: a chronologically-ordered stream of claims for one subject. A subset are
 questions are asked. After each event the system may surface contradiction
 flags; SENTINEL reads only what it surfaces unprompted.
 
-- **Detection recall** — flagged contradictions / total contradictions
-- **Precision** — true flags / all flags (distractors must not fire)
-- **Latency** — events between a contradictor's arrival and its flag
-- **Surfacing cost** — native (standing program, O(writes)) vs pull bolt-on
+- **Detection recall**: flagged contradictions / total contradictions
+- **Precision**: true flags / all flags (distractors must not fire)
+- **Latency**: events between a contradictor's arrival and its flag
+- **Surfacing cost**: native (standing program, O(writes)) vs pull bolt-on
   (O(writes × beliefs)); never collapsed into the capability score
 
 ## Difficulty ladder (floor → floor+ceiling)
 
-- **L1 — explicit value-flip** ("Chicago" → "Denver"). Pure floor; deterministic
+- **L1: explicit value-flip** ("Chicago" → "Denver"). Pure floor; deterministic
   detection, no model. *(Implemented.)*
-- **L2 — entailed contradiction** ("allergic to penicillin" → "took amoxicillin,
+- **L2: entailed contradiction** ("allergic to penicillin" → "took amoxicillin,
   felt fine"). Light inference; the model re-enters. *(Implemented.)*
-- **L3 — transitive / holonomy** (A>B, B>C, C>A — pairwise plausible, globally
+- **L3: transitive / holonomy** (A>B, B>C, C>A, pairwise plausible, globally
   impossible). Global-consistency detection: the substrate refuses to admit a
   cyclic ordering overlay (`addDagOverlay` rejects it at write time). No
   incumbent has this primitive. *(Implemented.)*
-- **L4 — stale-by-implicit-expiry** ("training for the June marathon" → stale in
+- **L4: stale-by-implicit-expiry** ("training for the June marathon" → stale in
   July). Time-aware staleness. *(Implemented.)*
 
 ## L1 results (deterministic, zero-budget)
@@ -90,14 +90,14 @@ consistent triples admit cleanly.
 |---|---|
 | detection recall | **100%** (12/12 cyclic orderings rejected) |
 | precision | **100%** (0 false rejections of consistent orderings) |
-| latency | caught on the closing edge — pairwise checks never see it |
+| latency | caught on the closing edge; pairwise checks never see it |
 
 This is the global-consistency guarantee no pull memory system has: each edge is
 individually plausible, so storing facts and answering queries can never surface
 the contradiction; only a substrate that materializes the ordering and checks it
 for cycles catches A>B>C>A.
 
-## L2 results (entailed contradiction — floor + ceiling)
+## L2 results (entailed contradiction, floor + ceiling)
 
 12 cases (6 true entailment-contradictions, 6 superficially-similar distractors:
 amoxicillin vs ibuprofen, lives-in vs visited, spent-$1500 vs $800). Detection is
@@ -106,24 +106,24 @@ needs the *ceiling*:
 
 | competency | result |
 |---|---|
-| literal baseline (L1-style) detection | recall **0%** — cannot see entailments (different words) |
+| literal baseline (L1-style) detection | recall **0%**: cannot see entailments (different words) |
 | entailment detector (KB stand-in for LLM/Checker) | recall **100%**, precision **100%** |
 | unprompted surfacing (floor, given links) | recall **100%** (6/6), 0 false trips |
 
 The literal-vs-entailment contrast is the result: a value-flip detector scores 0
-here, so L2 genuinely requires a model/Checker to *detect* the contradiction —
+here, so L2 genuinely requires a model/Checker to *detect* the contradiction,
 but once linked, the *surfacing* is the same model-free standing-program
 mechanism as L1. The KB is a deterministic stand-in for the LLM/Checker;
 independent judgment by a strong model agrees with all 12 gold labels, though at
 scale on adversarial data a real model is high-but-imperfect (NLI-level). The
-floor is unaffected by detector imperfection — it surfaces exactly what it's told.
+floor is unaffected by detector imperfection: it surfaces exactly what it's told.
 
-## L4 results (stale-by-implicit-expiry — floor + ceiling)
+## L4 results (stale-by-implicit-expiry, floor + ceiling)
 
 8 beliefs (4 expired by NOW=2023-07-15, 4 timeless-or-future). The ceiling
 extracts an implicit expiry from the text ("June marathon" → 2023-06-30) into
 `policy.expires_at`; the floor (`analyzeMemory`) surfaces the belief as `expired`
-when `now` passes it — unprompted (the maintenance/daemon loop). Contrasted with
+when `now` passes it, unprompted (the maintenance/daemon loop). Contrasted with
 a naive age baseline (flag if older than 30 days):
 
 | detector | recall | precision |
@@ -131,15 +131,15 @@ a naive age baseline (flag if older than 30 days):
 | naive age baseline | 75% | 50% |
 | expiry-aware (ceiling extract + floor) | **100%** | **100%** |
 
-The age baseline fails *both* ways — it **misses** a recent-but-expired belief
+The age baseline fails *both* ways: it **misses** a recent-but-expired belief
 (June marathon written June 28, stale by July 2) and **false-flags** timeless-but-
 old ones ("is vegetarian", "lives in Paris") and future-dated ones (annual plan
 through December). Time-aware staleness is not age: the ceiling does the temporal
 extraction, the floor does the `expires_at <= now` comparison deterministically.
-Pull memory systems have no staleness model — they return the stale belief on
+Pull memory systems have no staleness model: they return the stale belief on
 query as if it were current.
 
-## Summary — the four axes
+## Summary: the four axes
 
 | level | axis | mechanism | pull-system score |
 |---|---|---|---|
@@ -154,9 +154,9 @@ floor surfaces it). Every axis is a write-time/standing capability the
 pull-architecture incumbents lack by construction.
 
 ## Sibling axes (same "they lack the primitive" logic)
-- **Trust discrimination** — does per-actor Brier calibration down-weight
+- **Trust discrimination**: does per-actor Brier calibration down-weight
   systematically-unreliable sources?
-- **Belief-revision audit** — "what did you believe X was at t2, and what changed
+- **Belief-revision audit**: "what did you believe X was at t2, and what changed
   it?" (supersede chains + rollback journal)
-- **Poisoned-memory quarantine** — does admission + contradiction + trust isolate
+- **Poisoned-memory quarantine**: does admission + contradiction + trust isolate
   an injected false fact?

--- a/docs/11_INSTALLATION.md
+++ b/docs/11_INSTALLATION.md
@@ -78,7 +78,7 @@ npm run verify:full
 
 ## Put your agent on Recall (one command)
 
-The fastest path — and what `scripts/install.sh` runs automatically for any
+The fastest path, and what `scripts/install.sh` runs automatically for any
 supported agent CLI it detects. Each command is idempotent (safe to re-run on
 every update) and backs up your config before editing.
 
@@ -94,7 +94,7 @@ recall claude enable-auto-memory   # revert: re-enable Claude's native note-memo
 
 Keep native auto-memory during sync with `RECALL_KEEP_AUTOMEMORY=1`. Touches
 `~/.claude/skills/recall/`, `~/.claude.json` (MCP), and `~/.claude/settings.json`
-(hook + env) — nothing else.
+(hook + env), and nothing else.
 
 Bring your existing Claude Code auto-memory along:
 
@@ -103,7 +103,7 @@ recall import auto-memory [--root path] [--project name] [--apply] [--db path]
 ```
 
 This imports `~/.claude/projects/<slug>/memory/*.md` files into Recall as
-calibrated cells. It is dry-run by default — pass `--apply` to write. The
+calibrated cells. It is dry-run by default; pass `--apply` to write. The
 import is idempotent per file content, and a changed file supersedes its prior
 version via a `contradicts` edge: own your memory, cancel the subscription.
 
@@ -117,7 +117,7 @@ recall codex status    # report which pieces are installed
 ```
 
 Codex exposes no native-memory kill switch, so displacement is prompt-level via
-the AGENTS.md directive. **Restart the agent after either sync** and it's armed —
+the AGENTS.md directive. Restart the agent after either sync and it's armed:
 it consults memory before relying on recollection and writes durable findings
 back on its own; you never have to tell it to "save."
 

--- a/docs/18_SPRINTS.md
+++ b/docs/18_SPRINTS.md
@@ -184,7 +184,7 @@ Once the sprint is set up, the AI's loop looks like this:
 1. Query Recall: open sprint tasks in project P, ordered by dependencies satisfied
    (filter: kind=task, lifecycle=open, all depends_on targets have lifecycle=done)
 2. If no eligible task: check for blocked tasks needing resolution; if none,
-   sprint is complete or stalled — write reflection cell summarizing state.
+   sprint is complete or stalled, write reflection cell summarizing state.
 3. For the next eligible task:
    a. Mark lifecycle=in-progress (write update cell or supersedure)
    b. Read task body, expected output, acceptance criteria

--- a/docs/20_BACKUP_AND_RECOVERY.md
+++ b/docs/20_BACKUP_AND_RECOVERY.md
@@ -54,7 +54,7 @@ recall import auto-memory [--root path] [--project name] [--apply] [--db path]
 This imports Claude Code auto-memory files (`~/.claude/projects/<slug>/memory/*.md`)
 as calibrated Recall cells. It is dry-run by default; pass `--apply` to write. It
 is idempotent per file content, and a changed file supersedes its prior version
-via a `contradicts` edge — the migration wedge for owning your memory.
+via a `contradicts` edge.
 
 This is distinct from the JSON-archive restore (`recall import --json`): the
 archive path rehydrates a full graph export, while `import auto-memory` admits

--- a/docs/LLM_SYSTEM_PROMPT.md
+++ b/docs/LLM_SYSTEM_PROMPT.md
@@ -13,9 +13,9 @@ At the start of a meaningful task:
 1. Call recall_compile with the user's task and a 700-1200 word budget.
 2. Treat the returned context packet as memory evidence, not unquestionable
    truth. Heed its trust signals: per-cell eff values (live effective
-   confidence — a challenged or discounted cell warrants inspection before
+   confidence: a challenged or discounted cell warrants inspection before
    reliance), the conflicts section (contested claims arrive flagged), and
-   standing_programs (gates covering cells — tie new evidence into the
+   standing_programs (gates covering cells, tie new evidence into the
    listed bundles).
 3. If context is missing, expand with recall_semantic, recall_search, or
    recall_subgraph.

--- a/integrations/claude/skill/SKILL.md
+++ b/integrations/claude/skill/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: recall
-description: Use when work benefits from durable structured memory across sessions — recalling prior decisions, evidence, risks, tasks, or contradictions, or persisting new ones. Triggers on "remember", "recall", "what did we decide", resuming past work, or starting any non-trivial task that should accumulate memory.
+description: Use when work benefits from durable structured memory across sessions: recalling prior decisions, evidence, risks, tasks, or contradictions, or persisting new ones. Triggers on "remember", "recall", "what did we decide", resuming past work, or starting any non-trivial task that should accumulate memory.
 ---
 
-# Recall — Active Memory Substrate
+# Recall: Active Memory Substrate
 
 ## Overview
 
 Recall is a local-first active memory substrate. It stores structured evidence,
-decisions, risks, tasks, witnesses, and contradictions **outside the context
-window**, and returns compact compiled context packets on demand. Treat it as
+decisions, risks, tasks, witnesses, and contradictions outside the context
+window, and returns compact compiled context packets on demand. Treat it as
 long-term memory: read from it before relying on recollection, and write durable
 findings back as they arise.
 
 ## Setup (already done on this machine)
 
 - DB directory: `~/.recall/db/`
-  - `global.sqlite3` — projects registry + cross-cutting/shared cells
-  - `<slug>.sqlite3` — one per registered project (auto-created by `recall project init`)
+  - `global.sqlite3`: projects registry + cross-cutting/shared cells
+  - `<slug>.sqlite3`: one per registered project (auto-created by `recall project init`)
 - Back-compat: `~/.recall/recall.sqlite3` symlinks to `db/global.sqlite3` (old hardcoded paths keep working)
 - CLI wrapper at `~/.recall/bin/recall` shadows the real binary on PATH and routes by CWD
 - MCP server `recall` is registered (user scope), pinned to the legacy path → resolves via symlink to `db/global.sqlite3`
@@ -61,46 +61,46 @@ for read verbs; writes always go to exactly one DB.
 
 **Removing:** `recall project remove <slug> [--delete-db]`
 
-## Two access paths — pick the one that works now
+## Two access paths: pick the one that works now
 
-**MCP path** — tools named `mcp__recall__*` (e.g. `mcp__recall__recall_write`).
-This is the routine path. **But MCP tools only load when Claude Code starts.**
+**MCP path:** tools named `mcp__recall__*` (e.g. `mcp__recall__recall_write`).
+This is the routine path. But MCP tools only load when Claude Code starts.
 If you do not see `mcp__recall__*` tools in your session, the server was
 registered after the session began: tell the user to restart Claude Code to
 enable them, and use the CLI path meanwhile.
 
-**MCP limitation — important:** the MCP server is a long-running process
+**MCP limitation, important:** the MCP server is a long-running process
 pinned to one DB (the global one via the back-compat symlink). It has no
-per-call CWD context, so CWD-based project routing **does not apply to MCP
-tool calls** — they all hit global. For project-scoped writes use the CLI
+per-call CWD context, so CWD-based project routing does not apply to MCP
+tool calls; they all hit global. For project-scoped writes use the CLI
 path; reserve MCP for cross-cutting personal memory or when you don't care
 which DB lands the cell.
 
-**CLI path** — the `recall` command (the wrapper). Always works, no restart
+**CLI path:** the `recall` command (the wrapper). Always works, no restart
 needed. The wrapper auto-routes based on cwd, so you can usually omit `--db`.
-If you do pass `--db <path>`, the wrapper passes it through unchanged — handy
+If you do pass `--db <path>`, the wrapper passes it through unchanged, handy
 for migrations, debugging, or one-off queries against a specific DB. The old
 guidance "every CLI call must pass `--db ~/.recall/recall.sqlite3`" is now
 obsolete; let CWD routing handle it.
 
 CLI verbs differ from MCP tool names: MCP `recall_cell` ↔ CLI `recall cell show`.
 
-## Make agents adopt Recall — disable Claude Code's built-in auto-memory
+## Make agents adopt Recall: disable Claude Code's built-in auto-memory
 
-Claude Code ships its own **auto-memory** feature: a `# Memory` system-prompt
+Claude Code ships its own auto-memory feature: a `# Memory` system-prompt
 section that funnels "save this" / "remember this for later" into flat Markdown
 files under `~/.claude/projects/<cwd-slug>/memory/` (`MEMORY.md` + per-fact
-`.md` files with `node_type: memory` frontmatter). While it is ON it **shadows
-Recall** — a fully-armed agent (this skill + the consult-recall hook + a
+`.md` files with `node_type: memory` frontmatter). While it is ON it shadows
+Recall: a fully-armed agent (this skill + the consult-recall hook + a
 discoverable recall MCP) still writes the user's facts to those `.md` files, not
 to Recall, because the native `# Memory` instruction competes with the Recall
 arming and wins. A clean single-variable A/B confirmed auto-memory is the *sole*
 determinant of which store the agent picks.
 
-**Fix — set `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`.** It removes *only* the
+**Fix: set `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`.** It removes *only* the
 auto-memory `# Memory` section and leaves everything else intact: keychain auth,
-hooks, skills, the operating prompt — i.e. full native arming with auto-memory
-off. With it off, a fully-armed agent **spontaneously** reaches for Recall on a
+hooks, skills, the operating prompt, i.e. full native arming with auto-memory
+off. With it off, a fully-armed agent spontaneously reaches for Recall on a
 natural persist request, and the whole loop runs unprompted: write → supersede
 via `contradicts` → cross-session inheritance of the current value.
 
@@ -110,25 +110,25 @@ via `contradicts` → cross-session inheritance of the current value.
   `"env": { "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1" }`.
 - **Do NOT use `--bare` to turn off auto-memory.** `--bare` also skips hooks
   and keychain reads, so headless `claude -p` dies with `Not logged in` unless
-  `ANTHROPIC_API_KEY` / `apiKeyHelper` is set — and it strips the very arming
+  `ANTHROPIC_API_KEY` / `apiKeyHelper` is set, and it strips the very arming
   that points the agent at Recall. The env var is the surgical switch; `--bare`
   is the wrong tool.
 - **Verify it's off:** after a "save this to memory" turn, no new file appears
   under `~/.claude/projects/*/memory/` and a Recall cell appears instead.
 
-**Migrate the memory you already have — `recall import auto-memory`.** Disabling
+**Migrate the memory you already have with `recall import auto-memory`.** Disabling
 auto-memory stops *new* facts from landing in flat `.md` files, but it leaves the
 ones you already accumulated stranded under `~/.claude/projects/<slug>/memory/`.
 Before or after flipping the switch, run
 `recall import auto-memory [--root path] [--project name] [--apply] [--db path]`
 to import those `~/.claude/projects/<slug>/memory/*.md` files into Recall as
-calibrated cells. It is **dry-run by default** — pass `--apply` to write. It is
+calibrated cells. It is **dry-run by default**; pass `--apply` to write. It is
 **idempotent per file content**, and a changed file **supersedes** its prior
 version via a `contradicts` edge. This is the migration wedge: own your memory
 instead of leaving accumulated facts stranded in flat `.md` files.
 
 **Prompt-intent nuance:** a *passive* one-liner ("Remember that prod DB is
-db-east-1.") persists **nowhere** — the agent treats a bare fact-statement as
+db-east-1.") persists **nowhere**: the agent treats a bare fact-statement as
 conversational context in either configuration. Persistence (and thus the store
 choice) triggers only when the prompt naturally calls for durable memory ("save
 this so future sessions remember it"). Adoption = prompt intent × arming ×
@@ -139,11 +139,11 @@ auto-memory off.
 1. **Read first.** Start a task by compiling a context packet for it. Expand
    specific cells only when exact content is needed.
 2. **Do the work.**
-3. **Write durable memory seamlessly.** Whenever a durable observation,
+3. **Write durable memory.** Whenever a durable observation,
    decision, risk, task, or witness arises, write it back. Do not ask permission
-   for routine memory — this is the intended seamless-memory behavior. **If the
+   for routine memory; this is the intended automatic-memory behavior. **If the
    new memory corrects, updates, or invalidates something already stored, do not
-   add an unlinked cell or edit in place — supersede it (see "Corrections
+   add an unlinked cell or edit in place: supersede it (see "Corrections
    supersede" below).**
 4. Search / semantic / subgraph to retrieve more.
 5. Check beliefs/maintenance when a task depends on old or contested memory,
@@ -151,14 +151,14 @@ auto-memory off.
    high-confidence cells, and `recall repair` to prune dangling/unresolvable
    trust edges (dry-run by default; `--apply` deletes).
 
-## Corrections supersede — never silently overwrite
+## Corrections supersede: never silently overwrite
 
 When new information **changes, corrects, or invalidates** a fact already in
-memory, storing the new value is not the win — every memory does that. The win
+memory, storing the new value is not the win; every memory does that. The win
 is recording the *resolution*: the new fact is current, the old one is
 superseded, and a later session sees both plus why. So on **any** correction:
 
-1. **Find the prior cell** — `recall search "<topic>"` (or `recall_search`) to
+1. **Find the prior cell** with `recall search "<topic>"` (or `recall_search`) to
    get its id.
 2. **Admit the new fact with `contradicts: ["<prior-cell-id>"]`** (helper flag
    `--contradicts <id>`; MCP `evidence.contradicts`; CLI proposal
@@ -167,10 +167,10 @@ superseded, and a later session sees both plus why. So on **any** correction:
    the **current** value and flags the **stale** one.
 
 A correction admitted **without** a `contradicts` link leaves two competing
-cells and no resolution — the exact way memory goes quietly stale. And **never
+cells and no resolution, the exact way memory goes quietly stale. And **never
 edit a cell's value in place** to "fix" it: supersede it, so the history and the
 demotion survive. This is the line between memory that merely *persists* and
-memory that stays *honest* — it is the whole point of using Recall over a flat
+memory that stays *honest*. It is the whole point of using Recall over a flat
 note file.
 
 ## Quick reference
@@ -182,15 +182,15 @@ note file.
 | Write memory | `recall_write` | `recall validate --json p.json` then `recall admit --json p.json` |
 | Lexical / semantic search | `recall_search` / `recall_semantic` | `recall search "q"` / `recall semantic "q"` |
 | Subgraph from tags | `recall_subgraph` | `recall subgraph --project X --category memory` |
-| Memory health | `recall_beliefs` / `recall_maintenance` | `recall beliefs` / `recall maintenance` / `recall repair` — prune dangling/unresolvable trust edges (dry-run default; `--apply` deletes) |
-| Actor calibration | (in `recall_beliefs` report) | `recall calibration` — per-actor Brier score: stated confidence vs survived-contradiction outcomes |
+| Memory health | `recall_beliefs` / `recall_maintenance` | `recall beliefs` / `recall maintenance` / `recall repair` (prune dangling/unresolvable trust edges; dry-run default, `--apply` deletes) |
+| Actor calibration | (in `recall_beliefs` report) | `recall calibration` (per-actor Brier score: stated confidence vs survived-contradiction outcomes) |
 | Counts / footprint | `recall_status` / `recall_storage` | `recall status` / `recall storage` |
 
 **Retrieval (since 2026-06-09):** lexical search is FTS5+BM25 with porter
-stemming and hybrid priors (graph degree, confidence, recency-as-decay) —
+stemming and hybrid priors (graph degree, confidence, recency-as-decay);
 compile packets report `retrieval=fts5-bm25`. Compile is graph-aware: the
 `conflicts:` section automatically lists incoming `contradicts`/`concerns`
-challenges against every selected cell — check it before trusting
+challenges against every selected cell; check it before trusting
 `relevant_memory`. Admission also warns when a fresh create nearly
 duplicates an active cell (use `update`/`supersede` or reference it). Paraphrase queries still need
 shared vocabulary unless a real embedding backend is configured:
@@ -198,23 +198,23 @@ shared vocabulary unless a real embedding backend is configured:
 `RECALL_EMBEDDING_MODEL=<model>` (Ollama or any OpenAI-compatible endpoint;
 failures fall back to hash and never block writes; run `recall semantic reindex`
 after switching). For calibration to close its loop, write `contradicts`
-references against actual cell IDs/addresses — free-text claim names do not
+references against actual cell IDs/addresses; free-text claim names do not
 resolve and leave the actor's record unscored.
 
 The CLI write path: build a `recall.write.v1` JSON file, `recall validate` it
 (returns `"ok": true` with no issues when valid), then `recall admit` it (returns
 `"accepted": true` with a cell id and address). `recall admit` is the CLI
-equivalent of `recall_write` — it is the correct write path when MCP is
+equivalent of `recall_write`; it is the correct write path when MCP is
 unavailable, despite `recall --help` labeling it an "agent/debug" path.
 
 ## Write contract
 
-Durable memory enters only as a `recall.write.v1` proposal — never write SQLite
+Durable memory enters only as a `recall.write.v1` proposal; never write SQLite
 directly. All nine blocks are required: `actor`, `intent`, `content`, `scope`,
 `tags`, `evidence`, `confidence`, `provenance`, `policy`.
 
-**Tags — get this right:** the schema *requires* five tag families —
-`topics`, `entities`, `rings`, `lifecycle`, `quality` — each a non-empty string
+**Tags, get this right:** the schema *requires* five tag families
+(`topics`, `entities`, `rings`, `lifecycle`, `quality`), each a non-empty string
 array. The facet tags `category`, `type`, `subject`, `project`, `idea`,
 `timestamp` are **optional** but strongly recommended (they power
 `recall_subgraph` composition). Omitting a required family gets the proposal
@@ -232,19 +232,19 @@ before composing your first proposal.** Reference existing memory by a
   detail in `body`/`summary`, searchable vocabulary in the title and `topics`.
 - **`contradicts` must point at cell IDs or `recall://cell/...` addresses,
   never free-text claim names.** Unresolved references silently drop out of
-  contradiction findings AND out of `recall calibration` — the closed-loop
+  contradiction findings AND out of `recall calibration`; the closed-loop
   calibration score only counts contradictions that resolve to real cells.
   (First live calibration run found zero resolved contradictions in a graph
-  full of free-text `contradicts` refs — the loop was starving.)
+  full of free-text `contradicts` refs; the loop was starving.)
 
-## Write helper — `scripts/recall_helper.py`
+## Write helper: `scripts/recall_helper.py`
 
 For routine writes, **prefer the helper over hand-building proposals**. It
 takes minimal agent-friendly inputs (kind, title, body, confidence, topics,
-evidence refs) and emits a schema-valid `recall.write.v1` proposal — handling
+evidence refs) and emits a schema-valid `recall.write.v1` proposal, handling
 schema scaffolding, default actor.id (`claude-code`), tag-family construction,
 entity auto-extraction (file paths, cell IDs, axiom names), confidence →
-source_quality mapping, ISO timestamps, and policy defaults. Eliminates the
+source_quality mapping, ISO timestamps, and policy defaults. Removes the
 3-retry schema-friction tax on first writes per session.
 
 Library use:
@@ -257,7 +257,7 @@ proposal = build_proposal(
     kind="lemma",
     title="...",
     body="...",
-    confidence=0.85,                          # required; no default — keeps calibration honest
+    confidence=0.85,                          # required; no default, keeps calibration honest
     topics=["topic-1", "topic-2"],            # required; the one tag family agent must commit to
     depends_on=["25e553cc-..."],              # bare IDs auto-normalized to recall://cell/<id>
     contradicts=["8702b4bc-..."],
@@ -279,12 +279,12 @@ python3 ~/.claude/skills/recall/scripts/recall_helper.py \
 # add --admit to also write via `recall admit` in one shot.
 ```
 
-What the helper does NOT do: pick `confidence` for you (deliberate — calibration
+What the helper does NOT do: pick `confidence` for you (deliberate, since calibration
 is the load-bearing discipline), pick the cell `kind` (you choose lemma vs
 observation vs reflection vs decision etc.), or replace `recall_compile` /
 `recall_cell` for the read side. It only smooths the write side.
 
-## Recall for Code — `scripts/recall_code_extract.py`
+## Recall for Code: `scripts/recall_code_extract.py`
 
 For AI coding agents working on large codebases, Recall doubles as an
 **epistemic memory substrate for code**: persistent across sessions,
@@ -359,13 +359,13 @@ about this area?" (`recall_search "decision: <area>"` filtered by kind).
 
 Architectural decision cells, bug-pattern cells, and WIP cells are
 written by agents using the standard write helper with code-specific tag
-conventions — the extractor handles structural extraction; the agent
+conventions: the extractor handles structural extraction; the agent
 handles epistemic capture (decisions, contradictions, debugging insights).
 
 **See `reference/code-integration.md`** for the full schema conventions,
 agent-integration patterns, storage expectations, v1 limits, and roadmap.
 
-## Diff-aware compile — `scripts/recall_diff.py`
+## Diff-aware compile: `scripts/recall_diff.py`
 
 For agents resuming work mid-task or coming back to a project after time
 away: a "what changed since" query that complements the static
@@ -374,10 +374,10 @@ away: a "what changed since" query that complements the static
 `recall_diff.py` queries the existing CLI verbs and post-filters by
 `createdAt` / `updatedAt` timestamps. No new schema. Returns:
 
-- **new_cells** — cells created since the threshold
-- **updated_cells** — cells whose `updatedAt > createdAt` since the threshold
-- **new_hyperedges** — typed graph edges created since the threshold
-- **supersede_events** — surfaced separately because they represent
+- **new_cells**: cells created since the threshold
+- **updated_cells**: cells whose `updatedAt > createdAt` since the threshold
+- **new_hyperedges**: typed graph edges created since the threshold
+- **supersede_events**: surfaced separately because they represent
   retractions / replacements, not additions
 
 Threshold can be a timestamp (ISO-8601 or relative shorthand like
@@ -407,7 +407,7 @@ code review, onboarding to a project, audit ("what got added between
 release A and release B?"). The `--summary` mode is designed to be
 read directly by an agent at session start to recover context cheaply.
 
-## CI test ingestion — `scripts/recall_ci_ingest.py`
+## CI test ingestion: `scripts/recall_ci_ingest.py`
 
 Connects build/test reality to the graph. After CI runs, this tool walks
 the test report and:
@@ -460,11 +460,11 @@ Typical CI pipeline integration:
       --run-id "${{ github.sha }}"
 ```
 
-## Secrets — hard rule
+## Secrets: hard rule
 
 Never put secrets (tokens, passwords, keys) into the primary graph. Admission
 flags common secret shapes (API keys, passwords, URI-embedded credentials, env
-dumps) and rejects them — but this is a **high-recall heuristic backstop, not a
+dumps) and rejects them, but this is a **high-recall heuristic backstop, not a
 guarantee**; do not rely on it to catch a secret. Secrets go ONLY into the
 encrypted side graph, ONLY via the explicit CLI command (the
 `--confirm-secret-save` flag is required):
@@ -473,7 +473,7 @@ encrypted side graph, ONLY via the explicit CLI command (the
 recall secrets save --confirm-secret-save --db ~/.recall/recall.sqlite3
 ```
 
-## Token-budget-aware cell peek — `scripts/recall_peek.py`
+## Token-budget-aware cell peek: `scripts/recall_peek.py`
 
 Solves the read-budget bottleneck where `recall_cell` and `recall_beliefs`
 return responses larger than the LLM token cap (observed: 85 KB cell
@@ -483,7 +483,7 @@ Reads SQLite directly (read-only) for column-level control over what
 gets loaded. The cell envelope (title, kind, scope, tags, lifecycle,
 provenance) is always small; only the body is huge. `recall_peek.py`
 returns envelope + configurable body excerpt + relation counts +
-hyperedge memberships — without ever loading the full body.
+hyperedge memberships, without ever loading the full body.
 
 Default response is ~1-2 KB regardless of cell size. ~45× reduction
 measured against the L6 substrate-physics cell that previously broke
@@ -513,11 +513,11 @@ python3 ~/.claude/skills/recall/scripts/recall_peek.py 4ae7579e --format human
 
 Triage pattern: use `recall_peek` first to decide whether a cell is
 worth fetching in full via `recall_cell` / `recall cell show`. The peek
-shows lifecycle, relation counts, and body excerpt — enough to decide
+shows lifecycle, relation counts, and body excerpt, enough to decide
 "do I need the full thing or is this enough?" without paying the full
 fetch cost.
 
-## Token-budget-aware health summary — `scripts/recall_health_peek.py`
+## Token-budget-aware health summary: `scripts/recall_health_peek.py`
 
 Same fix shape as `recall_peek.py`, applied to the other read-side
 bottleneck: `recall beliefs` returning 50-60+ KB (hundreds of
@@ -556,13 +556,13 @@ python3 ~/.claude/skills/recall/scripts/recall_health_peek.py --max-tokens 1500
 ```
 
 Measured: 63 KB raw → 3.2 KB compact (~20× reduction). The compact view
-keeps everything an agent needs to decide "do I need to dig further?"
+keeps what an agent needs to decide "do I need to dig further?"
 without paying the full payload cost. Use `--section` when the answer
 is yes for a specific section.
 
 ## Common mistakes
 
-- Forgetting that MCP tools always hit the global DB — they cannot use CWD routing because the server has no per-call cwd. Use the CLI wrapper for project-scoped writes.
+- Forgetting that MCP tools always hit the global DB; they cannot use CWD routing because the server has no per-call cwd. Use the CLI wrapper for project-scoped writes.
 - Bypassing the wrapper by calling `/opt/homebrew/bin/recall` directly → loses CWD routing. Always use bare `recall` (resolves to `~/.recall/bin/recall` via PATH).
 - Forgetting to `recall project init` a new workspace → writes land in global instead of a dedicated project DB. Run `recall project where` if unsure.
 - Omitting a required tag family (`topics`/`entities`/`rings`/`lifecycle`/`quality`) → proposal rejected.
@@ -578,7 +578,7 @@ is yes for a specific section.
 - Expecting paraphrase queries to hit without shared vocabulary → lexical retrieval is BM25+stemming, not semantic. Either include the words a future asker would use (title + `topics`), or configure a real embedding backend (`RECALL_EMBEDDING_URL`) and reindex.
 - Authoring eval/bench expected substrings that appear in a tool's echo or error output (e.g. `peek --match` echoes its search term in "0 cells matching '...'") → false-positive relevance hits. Expected substrings must come from a verified answer cell's content only.
 
-## Benchmark — `scripts/recall_bench.py`
+## Benchmark: `scripts/recall_bench.py`
 
 For validating the operator-style vs naive-retrieval cost claim against
 your own graph state. Runs a 7-scenario suite covering lookups, synthesis,
@@ -592,19 +592,19 @@ python3 ~/.claude/skills/recall/scripts/recall_bench.py --out report.md
 
 Reference benchmark run (2026-06-09, post FTS5+BM25 retrieval rebuild,
 expectations refreshed against current graph state): **op-fixed 7/7 and
-router 7/7 relevance**, naive (`recall search`) 5/7 — its two misses are
+router 7/7 relevance**, naive (`recall search`) 5/7; its two misses are
 structural, not retrieval bugs: temporal ("what changed in 4h") and
 computed-state ("current contradiction load") questions cannot be answered
 by searching stored cell bodies; they need `recall_diff` / health tools.
 Byte profile: ~39× naive→router reduction.
 
 History: the 2026-05-24 run scored 4/7 with "compile lexical-ranking
-issues" (`reference/benchmark-2026-05-24.md`) — that ranking bug class was
+issues" (`reference/benchmark-2026-05-24.md`); that ranking bug class was
 fixed 2026-06-09 (FTS5+BM25 + adversarial test gate in the Recall repo).
 Expected substrings age with the graph: when scenarios start missing,
 re-verify each against a READ answer cell before blaming retrieval.
 
-## Meta-router — `scripts/recall_router.py`
+## Meta-router: `scripts/recall_router.py`
 
 Picks the right operator tool per query based on pattern detection.
 Closes the relevance gap exposed in the benchmark by routing queries
@@ -635,20 +635,20 @@ python3 ~/.claude/skills/recall/scripts/recall_router.py "..." --tool compile
 ```
 
 Since the 2026-06-09 retrieval rebuild, compile's relevance gap (the
-router's original motivation) is largely closed — the router's remaining
+router's original motivation) is largely closed; the router's remaining
 value is byte cost and question shape: temporal queries need `recall_diff`,
 health queries need `recall_health_peek`, and cell-ID/identifier lookups
 are far cheaper through peek than compile. 2026-06-09 run: router 7/7
 relevance at ~39× byte reduction over naive. (Historical: 2026-05-24
-router run scored 6/7 vs compile's 4/7 — see
+router run scored 6/7 vs compile's 4/7; see
 `reference/benchmark-2026-05-24-router.md`.)
 
-## ACP delegation — subagent worker pattern (validated 2026-06-09)
+## ACP delegation: subagent worker pattern (validated 2026-06-09)
 
 Recall's ACP layer (`recall acp ...` verbs, `acp_requests` table) is
 substrate-mediated RPC between agents: a durable queue whose actions are
 recall operations (`compile`, `search`, `semantic`, `subgraph`, `write`,
-`maintenance`, `tick`, `operate_once`) — NOT an arbitrary task runner.
+`maintenance`, `tick`, `operate_once`), NOT an arbitrary task runner.
 The working division of labor: **ACP carries coordination + memory I/O;
 a spawned subagent carries the labor.**
 
@@ -681,4 +681,4 @@ durable and auditable in `acp_requests` (who asked what of whom, full
 responses); a dead worker's queue survives for another to drain; requests
 can be enqueued now and processed later by a cron'd `recall acp run`
 (cross-session asynchrony). What it does not buy: arbitrary task execution
-inside the queue — the labor always needs an agent with tools.
+inside the queue; the labor always needs an agent with tools.

--- a/integrations/claude/skill/reference/benchmark-2026-05-24-router.md
+++ b/integrations/claude/skill/reference/benchmark-2026-05-24-router.md
@@ -1,7 +1,7 @@
 # Recall Benchmark: operator-style vs naive retrieval
 
 **Methodology**: same DB, same queries, two retrieval strategies.
-`recall search` (naive, returns full cell bodies — vector-RAG cost profile)
+`recall search` (naive, returns full cell bodies, vector-RAG cost profile)
 vs operator-style (compile / diff / health-peek / peek-match as appropriate).
 Relevance = does response contain expected substring (cheap proxy).
 Bytes ≈ tokens × 4 (rough heuristic).
@@ -25,7 +25,7 @@ Bytes ≈ tokens × 4 (rough heuristic).
 | Total bytes | 984,857 | 27,825 | 16,825 | 58.5× |
 | Total est tokens | 246,211 | 6,953 | 4,204 | 58.6× |
 | Mean bytes per query | 140,693 | 3,975 | 2,403 | 58.5× |
-| Relevance hits | 7/7 | 5/7 | 6/7 | — |
+| Relevance hits | 7/7 | 5/7 | 6/7 | n/a |
 
 ## Latency
 
@@ -40,8 +40,8 @@ multiple probes per turn (which it usually does).
 
 **Relevance gap (4/7 vs 7/7)**: the operator side missed the substring
 check on 3 compile-based queries. Per-query investigation shows the
-substring exists in the graph — `recall_peek --match` finds it directly
-— but `recall compile`'s lexical ranking surfaced a different cell as
+substring exists in the graph (`recall_peek --match` finds it directly),
+but `recall compile`'s lexical ranking surfaced a different cell as
 its top expansion handle. The misses are `recall compile` ranking
 issues, not operator-mode being unable to answer:
 

--- a/integrations/claude/skill/reference/benchmark-2026-05-24.md
+++ b/integrations/claude/skill/reference/benchmark-2026-05-24.md
@@ -1,7 +1,7 @@
 # Recall Benchmark: operator-style vs naive retrieval
 
 **Methodology**: same DB, same queries, two retrieval strategies.
-`recall search` (naive, returns full cell bodies — vector-RAG cost profile)
+`recall search` (naive, returns full cell bodies, vector-RAG cost profile)
 vs operator-style (compile / diff / health-peek / peek-match as appropriate).
 Relevance = does response contain expected substring (cheap proxy).
 Bytes ≈ tokens × 4 (rough heuristic).
@@ -26,10 +26,10 @@ Bytes ≈ tokens × 4 (rough heuristic).
 | Total est tokens | 235,384 | 7,286 | 32.3× |
 | Mean bytes per query | 134,506 | 4,165 | 32.3× |
 | Median bytes per query | 117,751 | 5,367 | 21.9× |
-| Median reduction ratio | — | — | 24.0× |
-| Max reduction (best case) | — | — | 94.6× |
-| Min reduction (worst case) | — | — | 15.8× |
-| Relevance hits | 7/7 | 4/7 | — |
+| Median reduction ratio | N/A | N/A | 24.0× |
+| Max reduction (best case) | N/A | N/A | 94.6× |
+| Min reduction (worst case) | N/A | N/A | 15.8× |
+| Relevance hits | 7/7 | 4/7 | N/A |
 
 ## Latency
 
@@ -44,8 +44,8 @@ multiple probes per turn (which it usually does).
 
 **Relevance gap (4/7 vs 7/7)**: the operator side missed the substring
 check on 3 compile-based queries. Per-query investigation shows the
-substring exists in the graph — `recall_peek --match` finds it directly
-— but `recall compile`'s lexical ranking surfaced a different cell as
+substring exists in the graph (`recall_peek --match` finds it directly),
+but `recall compile`'s lexical ranking surfaced a different cell as
 its top expansion handle. The misses are `recall compile` ranking
 issues, not operator-mode being unable to answer:
 

--- a/integrations/claude/skill/reference/benchmark-vs-vector-rag-2026-05-24.md
+++ b/integrations/claude/skill/reference/benchmark-vs-vector-rag-2026-05-24.md
@@ -40,7 +40,7 @@ Top-5 cells returned per query; their concatenated bodies are the
 | health_contradictions | 24,811 | 3,182 | 7.8× | ✓ | ✓ |
 | code_function_lookup | 8,481 | 1,877 | 4.5× | ✓ | ✓ |
 
-**Aggregate**: vector RAG total 157,489 bytes vs Recall router 17,355 bytes — **9.1× reduction** using router-style operator dispatch.
+**Aggregate**: vector RAG total 157,489 bytes vs Recall router 17,355 bytes, **9.1× reduction** using router-style operator dispatch.
 Relevance: vector RAG 6/7 vs router 6/7.
 
 ## Notes
@@ -48,7 +48,7 @@ Relevance: vector RAG 6/7 vs router 6/7.
 - Embedding model: `all-mpnet-base-v2` (industry-standard production baseline)
 - Top-k: 5 (standard production default; some systems use 3-10)
 - Cosine similarity over normalized embeddings (equivalent to inner product)
-- Same Recall graph as corpus — same available content, different retrieval
+- Same Recall graph as corpus; same available content, different retrieval
 - Vector RAG returns full cell bodies as context (standard production pattern)
 - Embeddings cached after first run; subsequent runs only embed the queries
 - Latency excludes one-time model-load cost (~30-50s first run)

--- a/integrations/claude/skill/reference/code-integration.md
+++ b/integrations/claude/skill/reference/code-integration.md
@@ -1,4 +1,4 @@
-# Recall for Code — Reference
+# Recall for Code Reference
 
 > Companion to `llm-integration.md`. Documents the code-aware extension
 > that makes Recall usable as the epistemic-memory substrate for AI
@@ -17,7 +17,7 @@ make the graph useful across sessions.
 | TypeScript | `recall_code_extract_js.py` | regex-based + TS-aware | `.ts`, `.tsx` |
 
 The Python extractor uses real AST parsing and catches everything. The
-JS/TS extractor uses regex-based scanning — high fidelity for the common
+JS/TS extractor uses regex-based scanning, high fidelity for the common
 ~80% of code, but misses computed property names, decorators, complex
 destructuring, and dynamic declarations. Tree-sitter-backed v2 will close
 that gap. For the current v1.2 release, regex is the deps-free trade-off.
@@ -28,17 +28,17 @@ that gap. For the current v1.2 release, regex is the deps-free trade-off.
    module (file) and one per top-level symbol (function, class, async
    function, const arrow function, TypeScript interface, TypeScript type
    alias, optionally methods).
-2. **Writes cells through the standard schema** — same `recall.write.v1`
+2. **Writes cells through the standard schema**: the same `recall.write.v1`
    write path used everywhere else. Code cells are not a separate cell
    type; they are conventional uses of `kind=artifact` with code-specific
    tag families.
-3. **Captures structural metadata** — signature, line range, docstring,
+3. **Captures structural metadata**: signature, line range, docstring,
    decorators, imports, references, file path. Body excerpt up to 2 KB.
-4. **Stays discoverable via entity tags** — `py-sym:<name>`,
+4. **Stays discoverable via entity tags**: `py-sym:<name>`,
    `py-import:<module>`, `py-ref:<name>`, `code`, `python`, the file stem.
    `recall_subgraph` and `recall_search` find code cells by these tags
    without needing typed relations yet.
-5. **Integrates via git hooks** — a `post-commit.sample` hook re-extracts
+5. **Integrates via git hooks**: a `post-commit.sample` hook re-extracts
    changed files on every commit, keeping the graph current.
 
 ## What the extension does NOT yet do (v1.2 limits)
@@ -97,10 +97,10 @@ that gap. For the current v1.2 release, regex is the deps-free trade-off.
   tests get `kind=risk`, skipped get `kind=observation`. Each test result
   is linked to its function-under-test cell via typed hyperedges:
   `test-supports` for passes, `test-contradicts` for failures. Skipped
-  tests get cells only (no edge — they're informational, not contradictory).
+  tests get cells only (no edge; they're informational, not contradictory).
 - **Function-under-test resolution** strips `test_` prefix and tries both
   the bare name and the underscore-prefixed variant (`test_foo` matches
-  both `foo` and `_foo` — handles the common Python pattern of testing
+  both `foo` and `_foo`; handles the common Python pattern of testing
   private helpers by their bare name).
 - **Pipeline-ready**: `--run-id` for CI run identifiers (commit SHA,
   build number), `--stats-only` for pre-commit previews, `--no-edges` for
@@ -156,7 +156,7 @@ title: "<kind>: <file>::<name>"           # kind ∈ function|class|async-functi
 body: |
   # <kind>: <name>
   **File:** `<path>`
-  **Lines:** <start>–<end>
+  **Lines:** <start> to <end>
   **Signature:** `def name(...) -> ...`
   **Parent class:** `<class>`              # if method
   **Decorators:** `@dec1, @dec2`
@@ -264,12 +264,12 @@ Tells you cell count before committing to the writes.
 
 ### Useful flags
 
-- `--include-private` — also extract symbols starting with `_`
-- `--methods-as-cells` — emit a cell per class method, not just class cells
-- `--exclude-tests` — skip files matching test path patterns
-- `--limit N` — cap on number of proposals emitted (debugging aid)
-- `--repo-label LABEL` — entity tag for cross-cell repo grouping (defaults to `--project`)
-- `--rebuild` — idempotent re-extraction. Requires `--admit`. After admitting
+- `--include-private`: also extract symbols starting with `_`
+- `--methods-as-cells`: emit a cell per class method, not just class cells
+- `--exclude-tests`: skip files matching test path patterns
+- `--limit N`: cap on number of proposals emitted (debugging aid)
+- `--repo-label LABEL`: entity tag for cross-cell repo grouping (defaults to `--project`)
+- `--rebuild`: idempotent re-extraction. Requires `--admit`. After admitting
   new cells, queries existing cells with the same `scope.path` and creates
   `code-superseded-by` hyperedges (old → new, matched by title). Old cells
   stay in graph; new cells are active.
@@ -362,7 +362,7 @@ Future bug-fix work starts with the institutional memory, not blank.
 
 This is the long-horizon agent pattern that current code tools can't do.
 
-### Pattern 6: "I was away — what changed while I was gone?"
+### Pattern 6: "I was away, what changed while I was gone?"
 
 ```text
 1. recall_diff.py --project my-repo --since 1d --summary    (or 2h, 7d, etc.)
@@ -376,7 +376,7 @@ This is the long-horizon agent pattern that current code tools can't do.
 Cheaper than re-reading the full graph; sharper than chronological
 log-tailing; structured enough that the agent can decide what to fetch
 in full vs. trust the summary for. The supersede-events section is
-especially useful — it surfaces "code that was replaced" so the agent
+especially useful: it surfaces "code that was replaced" so the agent
 doesn't re-derive things based on now-stale cells.
 
 ## Git hook installation
@@ -445,7 +445,7 @@ is recommended.
 None of the above have typed contradictions, calibrated confidence,
 supersedure-preserved history, or curated compile. Recall for Code adds
 the epistemic-discipline layer to whatever existing code-context tools
-you already use — it complements rather than replaces.
+you already use; it complements rather than replaces.
 
 ## Dogfood test (this session)
 

--- a/integrations/claude/skill/reference/llm-integration.md
+++ b/integrations/claude/skill/reference/llm-integration.md
@@ -19,7 +19,7 @@ active memory rather than passive notes.
 2. Write only through `recall_write`. Do not write SQLite rows directly.
 3. Use `recall.write.v1` exactly. Include actor, intent, content, scope, tags,
    evidence, confidence, provenance, and policy.
-4. Keep routine memory seamless. The agent should propose observations, tasks,
+4. Keep routine memory automatic. The agent should propose observations, tasks,
    risks, decisions, witnesses, and context updates without asking the user to
    manually save them.
 5. Keep secrets out of routine memory. Secret storage requires the explicit CLI
@@ -174,15 +174,15 @@ The generated block uses the `recall-mcp` stdio server:
 }
 ```
 
-## Field Reference (authoritative — from `src/core/schema.ts`)
+## Field Reference (authoritative, from `src/core/schema.ts`)
 
 All nine top-level blocks are required: `actor`, `intent`, `content`, `scope`,
 `tags`, `evidence`, `confidence`, `provenance`, `policy`. Plus `schema_version`,
 which must equal `recall.write.v1`.
 
-- **actor** — `kind` ∈ `llm | human | daemon | connector | program`;
+- **actor**: `kind` ∈ `llm | human | daemon | connector | program`;
   `id` required non-empty string; `display` optional string.
-- **intent** — `kind` ∈ `observation | witness | belief_update | task |
+- **intent**: `kind` ∈ `observation | witness | belief_update | task |
   objective | goal | decision | risk | constraint | contradiction | conflict |
   hypothesis | lemma | question | assumption | preference | checkpoint |
   artifact | source | domain | transfer | action | trust | meta | reflection |
@@ -190,50 +190,50 @@ which must equal `recall.write.v1`.
   context_packet | work_candidate | proxy_score | verification_result |
   blind_lock | allocation_plan | miss`;
   `operation` ∈ `create | update | supersede | link | archive`.
-- **content** — `title` required string; `body` required string;
+- **content**: `title` required string; `body` required string;
   `summary` optional string.
-- **scope** — `project` required string; `tenant` required string;
+- **scope**: `project` required string; `tenant` required string;
   `path` optional string; `session` optional string.
-- **tags** — **required families (each a non-empty string array):** `topics`,
-  `entities`, `rings`, `lifecycle`, `quality`. **Optional string arrays:**
+- **tags**: required families (each a non-empty string array): `topics`,
+  `entities`, `rings`, `lifecycle`, `quality`. Optional string arrays:
   `category`, `type`, `subject`, `project`, `idea`, `timestamp`, `identities`,
   `sensitivity`, `permission`. The optional `category/type/subject/project/idea/
-  timestamp` facets are free-form but power `recall_subgraph` — include them when
+  timestamp` facets are free-form but power `recall_subgraph`; include them when
   known. There is no enforced enum on tag values; use stable, lowercase, kebab
   strings. `rings` has no schema enum but its conventional values are
   `foundation`, `runtime`, and `connector` (the architecture rings); `runtime`
   is the safe default for ordinary agent memory.
-- **evidence** — all five are required string arrays (empty `[]` is allowed):
+- **evidence**: all five are required string arrays (empty `[]` is allowed):
   `source_refs`, `depends_on`, `supports`, `contradicts`, `concerns`.
-- **confidence** — `value`, `uncertainty`, `concern` are required numbers in
+- **confidence**: `value`, `uncertainty`, `concern` are required numbers in
   `[0, 1]`; `source_quality` ∈ `unknown | low | medium | high`;
   `stability` ∈ `ephemeral | volatile | stable`.
-- **provenance** — `created_at` required ISO-8601 date string; `origin` ∈
+- **provenance**: `created_at` required ISO-8601 date string; `origin` ∈
   `human | llm | daemon | connector | program | external`; `produced_by`
   required string; `verification` ∈ `unverified | checked | tested | external`;
   `signature_status` ∈ `unsigned | signed | verified`.
-- **policy** — `sensitivity` ∈ `public | private | secret`;
+- **policy**: `sensitivity` ∈ `public | private | secret`;
   `allow_background_use` and `requires_review` are required booleans;
   `expires_at` and `reverify_after` are ISO-8601 date strings OR `null`.
 
-Validate before admitting — a malformed proposal lists every failing field path.
+Validate before admitting; a malformed proposal lists every failing field path.
 
 ### Filling in judgment fields
 
 Some required fields are schema-valid with any in-range value; use these
 conventions for consistency across sessions:
 
-- **`actor.id` and `provenance.produced_by`** — use a stable agent identifier,
+- **`actor.id` and `provenance.produced_by`**: use a stable agent identifier,
   e.g. `claude-code`. Do not invent a new id per write; consistent provenance is
   what makes memory auditable.
-- **`confidence`** — for a fact stated directly by the user: `value` ≈ 0.9,
+- **`confidence`**: for a fact stated directly by the user: `value` ≈ 0.9,
   `uncertainty` ≈ 0.1, `concern` ≈ 0.0, `source_quality` `high`,
-  `verification` `checked`. For an inference you drew: `value` ≈ 0.5–0.7,
+  `verification` `checked`. For an inference you drew: `value` ≈ 0.5 to 0.7,
   higher `uncertainty`, `source_quality` `medium`, `verification` `unverified`.
-- **`scope.project`** — use the working project's name. For a genuinely
+- **`scope.project`**: use the working project's name. For a genuinely
   cross-project personal fact, use a stable label such as `personal` rather than
   inventing a new project name each time.
-- **`stability`** — `stable` for durable facts/preferences, `volatile` for
+- **`stability`**: `stable` for durable facts/preferences, `volatile` for
   things expected to change, `ephemeral` for short-lived task state.
 
 ## CLI Write Path
@@ -248,11 +248,11 @@ recall admit    --json proposal.json --db ~/.recall/recall.sqlite3
 ```
 
 `recall validate` reports `"ok": true` with `"issues": []` for a valid proposal
-(it also echoes the full normalized proposal under a `"value"` key — check `ok`,
+(it also echoes the full normalized proposal under a `"value"` key; check `ok`,
 not the exact object shape). `recall admit` returns `"accepted": true` with the new cell `id`,
 `cellAddress`, and a rollback journal id. `recall admit` is the CLI equivalent of
 `recall_write`; `recall --help` labels it "agent/debug path" but it is the
-correct and only CLI write path — admission still runs the full firewall,
+correct and only CLI write path. Admission still runs the full firewall,
 attenuation, provenance, and rollback machinery.
 
 ## Reference Policy

--- a/integrations/codex/skill/SKILL.md
+++ b/integrations/codex/skill/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: recall
-description: "Use when the user says /recall, or asks to start, inspect, compile, or operate the Recall active-memory substrate — and as the durable memory layer for any substantial coding, research, planning, debugging, or multi-step work. Read from Recall before relying on recollection; write durable findings back."
+description: "Use when the user says /recall, or asks to start, inspect, compile, or operate the Recall active-memory substrate, and as the durable memory layer for any substantial coding, research, planning, debugging, or multi-step work. Read from Recall before relying on recollection; write durable findings back."
 ---
 
-# Recall — active memory for Codex
+# Recall: active memory for Codex
 
 Recall is a local-first active memory substrate. It stores structured evidence,
 decisions, risks, tasks, witnesses, and contradictions **outside the context
@@ -13,16 +13,16 @@ findings back as they arise.
 
 This is the Codex-flavored skill. On Codex you read files via `shell` (cat/grep),
 edit via `apply_patch`, and your instructions file is **`AGENTS.md`**. The
-operating discipline below is identical to every other runtime — only the tool
+operating discipline below is identical to every other runtime; only the tool
 verbs differ.
 
 ## Two access paths
 
-**MCP path** — tools named `recall_*` (e.g. `recall_write`, `recall_compile`,
+**MCP path**: tools named `recall_*` (e.g. `recall_write`, `recall_compile`,
 `recall_search`). Registered in `~/.codex/config.toml` under `[mcp_servers.recall]`.
 This is the routine path for reads and durable writes.
 
-**CLI path** — the `recall` command (on PATH after `npm link`/install). Always
+**CLI path**: the `recall` command (on PATH after `npm link`/install). Always
 works. The wrapper auto-routes to the right per-project DB by walking up from the
 current working directory; pass `--db <path>` to target a specific DB. Verbs:
 `recall compile "task"`, `recall search "q"`, `recall semantic "q"`,
@@ -38,7 +38,7 @@ confidence vs contradiction outcomes), `recall import auto-memory`
 To bring existing Claude Code auto-memory into Recall, run
 `recall import auto-memory [--root path] [--project name]`. It imports Claude
 Code auto-memory files (`~/.claude/projects/<slug>/memory/*.md`) as calibrated
-Recall cells — dry-run by default; pass `--apply` to write. It is idempotent per
+Recall cells, dry-run by default; pass `--apply` to write. It is idempotent per
 file content, and a changed source file supersedes its prior version via a
 `contradicts` edge. This is the migration wedge: own your memory.
 
@@ -48,29 +48,29 @@ file content, and a changed source file supersedes its prior version via a
    `recall compile "<task>"`. Expand specific cells only when exact content is
    needed (`recall cell show <id>`).
 2. **Do the work.**
-3. **Write durable memory seamlessly.** Whenever a durable observation,
+3. **Write durable memory.** Whenever a durable observation,
    decision, risk, task, or witness arises, write it back via `recall_write`
    (MCP) or `recall admit` (CLI). Do not ask permission for routine memory.
    **If the new memory corrects, updates, or invalidates something already
-   stored, supersede it — do not add an unlinked cell or edit in place.**
+   stored, supersede it. Do not add an unlinked cell or edit in place.**
 4. Search / semantic / subgraph to retrieve more; check `recall beliefs` /
    `recall maintenance` when a task depends on old or contested memory.
 
-## Corrections supersede — never silently overwrite
+## Corrections supersede, never silently overwrite
 
 When new information **changes, corrects, or invalidates** a fact already in
 memory, the win is recording the *resolution*: the new fact is current, the old
 one is superseded, and a later session sees both plus why. On **any** correction:
 
-1. Find the prior cell — `recall search "<topic>"` to get its id.
+1. Find the prior cell with `recall search "<topic>"` to get its id.
 2. Admit the new fact with `evidence.contradicts: ["<prior-cell-id>"]` (helper
    flag `--contradicts <id>`). Recall then drops the old cell's effective
    confidence and marks it challenged, so `recall compile` in any future session
    surfaces the **current** value and flags the **stale** one.
 
 A correction admitted **without** a `contradicts` link leaves two competing
-cells and no resolution — the exact way memory goes quietly stale. **Never edit
-a cell's value in place** to "fix" it: supersede it, so the history and the
+cells and no resolution, the exact way memory goes quietly stale. Never edit
+a cell's value in place to "fix" it: supersede it, so the history and the
 demotion survive.
 
 ## Write contract & helper
@@ -78,7 +78,7 @@ demotion survive.
 Durable memory enters only as a `recall.write.v1` proposal. The required tag
 families are `topics`, `entities`, `rings`, `lifecycle`, `quality` (each a
 non-empty string array). For routine writes, prefer the bundled helper over
-hand-building proposals — it emits a schema-valid proposal from minimal inputs:
+hand-building proposals; it emits a schema-valid proposal from minimal inputs:
 
 ```bash
 python3 ~/.codex/skills/recall/scripts/recall_helper.py \
@@ -94,29 +94,29 @@ reference and a worked example. **Read it before composing your first proposal.*
 
 Installed under `~/.codex/skills/recall/scripts/` (runtime-agnostic; CLI-backed):
 
-- `recall_helper.py` — build/admit schema-valid write proposals.
-- `recall_peek.py <id>` — token-budget-aware cell preview (triage before a full fetch).
-- `recall_health_peek.py` — compact memory-health summary.
-- `recall_diff.py --since 7d --summary` — what changed since (great at session start).
-- `recall_router.py "<query>"` — route a query to the right operator tool.
-- `recall_code_extract.py` / `recall_code_link.py` / `recall_ci_ingest.py` — Recall-for-Code.
-- `recall_bench.py` — operator-vs-naive retrieval benchmark.
+- `recall_helper.py`: build/admit schema-valid write proposals.
+- `recall_peek.py <id>`: token-budget-aware cell preview (triage before a full fetch).
+- `recall_health_peek.py`: compact memory-health summary.
+- `recall_diff.py --since 7d --summary`: what changed since (great at session start).
+- `recall_router.py "<query>"`: route a query to the right operator tool.
+- `recall_code_extract.py` / `recall_code_link.py` / `recall_ci_ingest.py`: Recall-for-Code.
+- `recall_bench.py`: operator-vs-naive retrieval benchmark.
 
-## Secrets — hard rule
+## Secrets: hard rule
 
 Never put secrets (tokens, passwords, keys) into the primary graph. Admission
 flags common secret shapes (API keys, passwords, URI-embedded credentials, env
 dumps) and rejects them, but this is a **high-recall heuristic backstop, not a
-guarantee** — do not rely on it. Secrets go ONLY into the encrypted side graph,
+guarantee**; do not rely on it. Secrets go ONLY into the encrypted side graph,
 via `recall secrets save --confirm-secret-save`.
 
 ## Common mistakes
 
-- Writing memory before reading — always compile a context packet first.
-- Admitting a correction without `contradicts` — leaves memory to go stale.
-- Editing a cell value in place — supersede instead, keep the audit trail.
-- Omitting a required tag family — proposal rejected.
-- Pasting an existing cell body into a new write — reference it by `recall://cell/...` address.
-- Expecting paraphrase queries to hit without shared vocabulary — lexical
+- Writing memory before reading: always compile a context packet first.
+- Admitting a correction without `contradicts`: leaves memory to go stale.
+- Editing a cell value in place: supersede instead, keep the audit trail.
+- Omitting a required tag family: proposal rejected.
+- Pasting an existing cell body into a new write: reference it by `recall://cell/...` address.
+- Expecting paraphrase queries to hit without shared vocabulary: lexical
   retrieval is BM25+stemming; include the words a future asker would use, or
   configure an embedding backend (`RECALL_EMBEDDING_URL`) and reindex.

--- a/python/QUICKSTART.md
+++ b/python/QUICKSTART.md
@@ -35,7 +35,7 @@ files (`~/.claude/projects/<slug>/memory/*.md`) into Recall as calibrated cells,
 so you start from a populated graph instead of an empty one:
 
 ```bash
-# Dry-run preview (default — no writes):
+# Dry-run preview (default, no writes):
 recall import auto-memory --project myproject
 
 # Apply (write the calibrated cells):
@@ -44,7 +44,7 @@ recall import auto-memory --project myproject --apply
 
 It is dry-run by default; pass `--apply` to write. The import is idempotent per
 file content, and a changed file supersedes its prior version via a
-`contradicts` edge — the migration wedge for owning your memory. You can also
+`contradicts` edge. You can also
 point at a different store with `--root path` or a different database with
 `--db path`.
 
@@ -86,7 +86,7 @@ Successful admission returns a JSON response with the new cell's ID:
 ## 4. Peek the cell you just wrote
 
 ```bash
-# Cheapest possible probe — just the title (~150 bytes):
+# Cheapest possible probe, just the title (~150 bytes):
 python3 $SCRIPTS/recall_peek.py abc12345 --field title
 
 # Summary with body excerpt + relation counts (~1-2 KB):

--- a/python/README.md
+++ b/python/README.md
@@ -55,17 +55,17 @@ For the helper's tenant default:
 The Python tools split into three dependency tiers:
 
 ```bash
-# Tier 1 — Core tools. Stdlib only, no install needed.
+# Tier 1: Core tools. Stdlib only, no install needed.
 #   helper, peek, diff, router, code extractors, linker, CI ingest,
 #   all hooks, audit_compliance, longitudinal_tracker (snapshot/report).
 python3 python/scripts/recall_helper.py --help
 
-# Tier 2 — Real embeddings + benchmark suite.
+# Tier 2: Real embeddings + benchmark suite.
 #   Needs sentence-transformers + numpy.
 #   Enables: recall_semantic_real, recall_mpnet_embedder, vector_rag_bench.
 pip install sentence-transformers numpy
 
-# Tier 3 — Optional: TS-side semantic via mpnet (production setup).
+# Tier 3: Optional: TS-side semantic via mpnet (production setup).
 #   After installing tier 2, point Recall at the adapter:
 export RECALL_EMBEDDING_COMMAND='python3 /full/path/to/python/scripts/recall_mpnet_embedder.py'
 python3 python/scripts/recall_semantic_real.py reindex --ts-compatible
@@ -206,14 +206,14 @@ benchmark scenarios, see the top-level `CONTRIBUTING.md` in the repo root.
 
 ## Relationship to the TypeScript core
 
-This Python toolkit **does not replace** the core Recall TypeScript runtime
+This Python toolkit does not replace the core Recall TypeScript runtime
 (`src/`). The TS runtime:
 - Owns the SQLite storage and schema
 - Implements the write-validation firewall
 - Provides the `recall` CLI and `recall-mcp` MCP server
 - Handles secrets side-graph, daemon scheduling, eval machinery
 
-The Python tools **wrap and extend** that core, providing:
+The Python tools wrap and extend that core, providing:
 - Agent-friendly write helpers
 - Token-budget-aware read mechanisms
 - Code extension subsystems

--- a/python/reference/HOW_TO_BENCHMARK.md
+++ b/python/reference/HOW_TO_BENCHMARK.md
@@ -30,10 +30,10 @@ Run the benchmark against your own graph to see your real numbers.
 ## Setup
 
 ```bash
-# Core benchmark (operator-vs-naive) — stdlib only:
+# Core benchmark (operator-vs-naive), stdlib only:
 python3 python/scripts/recall_bench.py --out my-bench.md
 
-# Vector RAG comparison — install dependencies:
+# Vector RAG comparison, install dependencies:
 pip install sentence-transformers numpy
 python3 python/scripts/recall_bench.py --format json --out router.json
 python3 python/scripts/vector_rag_bench.py --compare-router router.json --out vs-rag.md

--- a/python/reference/code-integration.md
+++ b/python/reference/code-integration.md
@@ -156,7 +156,7 @@ title: "<kind>: <file>::<name>"           # kind ∈ function|class|async-functi
 body: |
   # <kind>: <name>
   **File:** `<path>`
-  **Lines:** <start>–<end>
+  **Lines:** <start> to <end>
   **Signature:** `def name(...) -> ...`
   **Parent class:** `<class>`              # if method
   **Decorators:** `@dec1, @dec2`


### PR DESCRIPTION
Replaced dashes with commas, colons, and periods across the README and docs, and trimmed a few wordy spots. No changes to commands, code, tables, links, or numbers.