### PR TITLE
Danger-proportional dig cue: flag superseded/stale rows in the mini-index

### DIFF
--- a/integrations/claude/hooks/recall-session-start.py
+++ b/integrations/claude/hooks/recall-session-start.py
@@ -185,35 +185,57 @@ def prompt_digest(prompt: str, cwd: str) -> str:
     if not rel:
         return ""
 
-    # ids + titles only: strip the trailing [kind:id], keep a short id, and
-    # truncate what remains (which is title-first) so summaries do not bleed in.
+    # Danger sets: which cells are the SUPERSEDED side of a contradiction (the
+    # target after `->`) or are flagged stale. Used to mark a row only when the
+    # row ITSELF may not be current, so the dig call scales with real risk
+    # instead of crying wolf on every dense-graph supersession trail.
+    conflict_lines = secs.get("conflicts", [])
+    stale_lines = secs.get("stale_or_low_trust", [])
+    challenged_ids = set(re.findall(r"->([0-9a-f]{8})", " ".join(conflict_lines)))
+    stale_ids = set(re.findall(r"stale:([0-9a-f]{8})", " ".join(stale_lines)))
+
+    # ids + titles only: strip the trailing [kind:id], keep a short id, truncate
+    # the rest (title-first), and flag the row if the cell is itself stale/superseded.
     index = []
+    flagged = False
     for ln in rel[:5]:
         m = re.search(r"\[([a-z_]+):([0-9a-f]{8})[0-9a-f-]*\]\s*$", ln)
+        short = m.group(2) if m else ""
         cid = f"{m.group(1)}:{m.group(2)}" if m else ""
         body = re.sub(r"\s*\[[a-z_]+:[0-9a-f-]+\]\s*$", "", ln).lstrip("- ").strip()
-        index.append(f"- {_trim(body, 110)}" + (f"  [{cid}]" if cid else ""))
+        tag = ""
+        if short and short in stale_ids:
+            tag, flagged = "  [STALE]", True
+        elif short and short in challenged_ids:
+            tag, flagged = "  [SUPERSEDED?]", True
+        index.append(f"- {_trim(body, 110)}" + (f"  [{cid}]" if cid else "") + tag)
     if not index:
         return ""
 
     parts = ["[Recall mini-index for THIS prompt (ids + titles only). You now know what exists, so do not ask or assert blind:]"]
     parts += index
 
-    n_conf = len(secs.get("conflicts", []))
-    n_stale = len(secs.get("stale_or_low_trust", []))
-    flags = []
-    if n_conf:
-        flags.append(f"{n_conf} challenged")
-    if n_stale:
-        flags.append(f"{n_stale} stale/low-trust")
-    if flags:
-        parts.append("tripwires touching this topic: " + ", ".join(flags) + ".")
-
-    parts.append(
-        "This is awareness, NOT a substitute. For anything load-bearing, run "
-        'recall compile "<task>" for bodies, the full conflict trace, and calibration, '
-        "and use search / subgraph / recall cell show <id> to dig."
-    )
+    if flagged:
+        # A SHOWN row may not be current: reading its title alone is unsafe.
+        parts.append(
+            "DIG REQUIRED: a row above is marked [SUPERSEDED?] or [STALE]; its title may be out of date. "
+            'Run recall compile "<task>" and recall cell show <id> on it BEFORE you act on it.'
+        )
+    elif conflict_lines or stale_lines:
+        bits = []
+        if conflict_lines:
+            bits.append(f"{len(conflict_lines)} challenged")
+        if stale_lines:
+            bits.append(f"{len(stale_lines)} stale/low-trust")
+        parts.append(
+            "tripwires elsewhere on this topic (" + ", ".join(bits) + "). "
+            'If you act here, run recall compile "<task>" for the conflict trace first.'
+        )
+    else:
+        parts.append(
+            "This is awareness, not a substitute. For anything load-bearing, run "
+            'recall compile "<task>" for bodies and calibration, and search / subgraph / cell show to dig.'
+        )
     return "\n".join(parts)
 
 

--- a/integrations/claude/hooks/recall-session-start.py
+++ b/integrations/claude/hooks/recall-session-start.py
@@ -1,18 +1,30 @@
 #!/usr/bin/env python3
-"""SessionStart hook: auto-consult the Recall active-memory substrate.
+"""SessionStart + UserPromptSubmit hook for the Recall active-memory substrate.
 
-Injects, as model context at the start of every session:
-  1. A standing directive to consult Recall before relying on recollection
-     (fixes the "agent forgets to look" failure mode), and
-  2. A cheap recent-activity summary (last 7d), scoped to whichever Recall DB
-     the current directory routes to (a registered project's DB, or the global
-     DB when the cwd matches no project). The scope is labelled accurately.
+Two modes:
 
-Fail-open by design: if the diff query is slow, missing, or errors, we still
-emit the directive alone. A SessionStart hook must never break session launch.
+  default (SessionStart): emit the standing directive plus a cheap 7d
+    recent-activity summary, scoped to whichever Recall DB the current
+    directory routes to (a registered project's DB, or the global DB when the
+    cwd matches no project). The scope is labelled accurately.
+
+  --prompt (UserPromptSubmit): emit the directive plus a MINI index of the
+    cells relevant to the incoming prompt (ids + titles only) and a count of
+    the tripwires (challenged / stale cells) touching the topic. This is the
+    push step: instead of telling the agent to go read Recall (which it can
+    route around), the relevant ids and titles are pushed into context so the
+    agent cannot ask or assert blind. It is deliberately INCOMPLETE: bodies, the
+    conflict trace, and calibration are withheld on purpose, so the agent still
+    runs a real `recall compile` and keeps the deeper tooling (search, subgraph,
+    cell expansion) in play. The push is the invitation, not the substitute.
+
+Fail-open by design: any error, timeout, or missing dependency falls back to the
+directive alone. A prompt/session hook must never break submission. The
+per-prompt compile is given a hard 4s timeout because it runs on every prompt.
 """
 import json
 import os
+import shutil
 import subprocess
 import sys
 
@@ -21,20 +33,45 @@ DIFF = os.path.expanduser("~/.claude/skills/recall/scripts/recall_diff.py")
 _MISSING_DIFF_SENTINEL = os.path.expanduser("~/.claude/.recall-diff-missing.warned")
 
 DIRECTIVE = (
-    "[Recall active memory is available — consult it before trusting recollection.]\n"
+    "[Recall active memory is available. Consult it before trusting recollection.]\n"
     "Before relying on memory for a task this session, read from Recall first:\n"
-    '  • recall compile "<task>"   — compiled context packet for what you are about to do\n'
-    '  • recall search "<query>"   — lexical / semantic lookup\n'
-    "  • python3 ~/.claude/skills/recall/scripts/recall_peek.py <id>   — cheap cell preview\n"
+    '  - recall compile "<task>"   : compiled context packet for what you are about to do\n'
+    '  - recall search "<query>"   : lexical / semantic lookup\n'
+    "  - python3 ~/.claude/skills/recall/scripts/recall_peek.py <id>   : cheap cell preview\n"
+    "Asking the user for a fact you could retrieve is the same failure as asserting from "
+    "unchecked memory: search Recall before asking.\n"
     "Write durable findings back via the write helper / `recall admit`. "
     "Do not assert from memory you have not checked here."
 )
 
 
+def recall_bin() -> str:
+    """Resolve the recall wrapper (does the cwd-based DB routing). Wrapper first, then PATH."""
+    for cand in (
+        os.path.expanduser("~/.recall/bin/recall"),
+        shutil.which("recall"),
+        "/opt/homebrew/bin/recall",
+    ):
+        if cand and os.path.exists(cand):
+            return cand
+    return ""
+
+
+def read_hook_input() -> dict:
+    """Parse the hook stdin JSON. Returns {} on tty / empty / malformed input."""
+    try:
+        if sys.stdin.isatty():
+            return {}
+        raw = sys.stdin.read()
+        return json.loads(raw) if raw.strip() else {}
+    except Exception:
+        return {}
+
+
 def _scope_label():
     """Describe the DB the cwd routes to, so the activity summary is labelled
     honestly. Returns (label, ok). Mirrors the recall wrapper's CWD routing via
-    `recall project where`. Fail-open: any error → a neutral, non-overclaiming label."""
+    `recall project where`. Fail-open: any error returns a neutral, non-overclaiming label."""
     try:
         out = subprocess.run(
             ["recall", "project", "where"],
@@ -82,17 +119,122 @@ def recent_summary() -> str:
         return ""
 
 
+def _sections(text: str, names) -> dict:
+    """Slice top-level sections out of a `recall compile` text packet.
+
+    A section starts at a line `^<name>:` and runs until the next such header.
+    Returns {name: [content_lines]} for the requested names, dropping blanks and
+    the literal `- none` placeholder.
+    """
+    import re
+
+    lines = text.splitlines()
+    headers = [
+        (i, m.group(1))
+        for i, ln in enumerate(lines)
+        for m in [re.match(r"^([a-z_]+):\s*$", ln)]
+        if m
+    ]
+    out = {}
+    for idx, (i, name) in enumerate(headers):
+        if name not in names:
+            continue
+        end = headers[idx + 1][0] if idx + 1 < len(headers) else len(lines)
+        body = [l for l in lines[i + 1:end] if l.strip() and l.strip() != "- none"]
+        out[name] = body
+    return out
+
+
+def _trim(line: str, n: int) -> str:
+    line = line.strip()
+    return (line[: n - 1] + "…") if len(line) > n else line
+
+
+def prompt_digest(prompt: str, cwd: str) -> str:
+    """Build a MINI index of cells relevant to `prompt`: ids + titles only, plus
+    a count of the tripwires (challenged / stale cells) touching the topic.
+
+    Deliberately incomplete. It makes Recall ambient and names what exists so the
+    agent cannot ask or assert blind, but it withholds bodies, the conflict trace,
+    and calibration ON PURPOSE, so the agent still runs a real `recall compile`
+    and keeps the deeper tooling (search, subgraph, cell expansion) in play.
+
+    Returns "" on short prompt, missing binary, error, timeout, or no match
+    (relevance gating: a weak/empty match pushes nothing extra).
+    """
+    import re
+
+    prompt = (prompt or "").strip()
+    if len(prompt) < 6:
+        return ""
+    recall = recall_bin()
+    if not recall:
+        return ""
+    try:
+        res = subprocess.run(
+            [recall, "compile", prompt[:400]],
+            capture_output=True, text=True, timeout=4,
+            cwd=(cwd if cwd and os.path.isdir(cwd) else None),
+        )
+        out = res.stdout or ""
+    except Exception:
+        return ""
+
+    secs = _sections(out, ["relevant_memory", "conflicts", "stale_or_low_trust"])
+    rel = secs.get("relevant_memory", [])
+    if not rel:
+        return ""
+
+    # ids + titles only: strip the trailing [kind:id], keep a short id, and
+    # truncate what remains (which is title-first) so summaries do not bleed in.
+    index = []
+    for ln in rel[:5]:
+        m = re.search(r"\[([a-z_]+):([0-9a-f]{8})[0-9a-f-]*\]\s*$", ln)
+        cid = f"{m.group(1)}:{m.group(2)}" if m else ""
+        body = re.sub(r"\s*\[[a-z_]+:[0-9a-f-]+\]\s*$", "", ln).lstrip("- ").strip()
+        index.append(f"- {_trim(body, 110)}" + (f"  [{cid}]" if cid else ""))
+    if not index:
+        return ""
+
+    parts = ["[Recall mini-index for THIS prompt (ids + titles only). You now know what exists, so do not ask or assert blind:]"]
+    parts += index
+
+    n_conf = len(secs.get("conflicts", []))
+    n_stale = len(secs.get("stale_or_low_trust", []))
+    flags = []
+    if n_conf:
+        flags.append(f"{n_conf} challenged")
+    if n_stale:
+        flags.append(f"{n_stale} stale/low-trust")
+    if flags:
+        parts.append("tripwires touching this topic: " + ", ".join(flags) + ".")
+
+    parts.append(
+        "This is awareness, NOT a substitute. For anything load-bearing, run "
+        'recall compile "<task>" for bodies, the full conflict trace, and calibration, '
+        "and use search / subgraph / recall cell show <id> to dig."
+    )
+    return "\n".join(parts)
+
+
 def main() -> int:
-    # --prompt: lightweight per-prompt nudge (directive only, ~126 tokens, no diff).
+    # --prompt: per-prompt push (directive + mini relevance index).
     # default: full SessionStart payload (directive + 7d recent-activity diff).
     prompt_mode = "--prompt" in sys.argv[1:]
     event = "UserPromptSubmit" if prompt_mode else "SessionStart"
+    data = read_hook_input()
+
     ctx = DIRECTIVE
-    if not prompt_mode:
+    if prompt_mode:
+        digest = prompt_digest(data.get("prompt", ""), data.get("cwd", ""))
+        if digest:
+            ctx = digest + "\n\n" + DIRECTIVE
+    else:
         summary = recent_summary()
         if summary:
             label, _ = _scope_label()
             ctx += f"\n\nRecent graph activity (last 7d, {label}):\n" + summary
+
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": event,


### PR DESCRIPTION
## What
The per-prompt mini-index now flags any shown row that is itself the superseded side of a contradiction, or is stale, with [SUPERSEDED?] or [STALE], and escalates to a hard DIG REQUIRED only when a SHOWN row is flagged.

## Why
The previous mini-index ended with a flat dig cue that read the same whether the topic was clean or whether a cell about to be relied on was actually superseded. In a dense graph there are always healthy supersession trails, so a flat hard warning would cry wolf and get tuned out. Tying the imperative to per-row risk keeps the loud version rare and therefore credible.

## Behavior
- A shown row that is the superseded target of a contradiction, or is stale, is marked inline.
- If any shown row is flagged: DIG REQUIRED, run compile and cell show on it before acting.
- Conflicts touching the topic but not in the shown rows: a soft trace pointer.
- Clean topic: the light awareness cue.

Fail-open, relevance-gated, cwd-scoped, 4s timeout preserved. Follow-up to the per-prompt push PR (#16).