### PR TITLE
Auto-memory substitute: README section + danger-proportional dig cue

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,36 @@ Recall makes a few opinionated bets that most memory layers don't:
 The common thread is auditability: provenance on every cell, a firewall on
 every write, and a packet you can actually read.
 
+## A real substitute for built-in auto-memory
+
+Coding agents ship their own memory: a feature that funnels "remember this"
+into flat Markdown files and reads them back every turn. It has one real
+strength, it is ambient. It sits in context the whole time, so the agent
+never has to decide to use it. Everything else about it is thin: the notes
+are flat, corrections pile up with no supersession, there is no trust or
+calibration, and the files are siloed per tool.
+
+Recall closes the one gap and keeps the rest. A session-start hook and a
+per-prompt hook push a small, trust-annotated index of the cells relevant to
+what you just typed straight into the agent's context, so Recall is ambient
+too, with the answer already present instead of a tool the agent has to
+remember to call. That index marks any cell that has been superseded or has
+gone stale, which a flat file can never do, since a pile of notes just
+accumulates contradictions in silence. The short version: the substrate is
+the continuity the agent does not have between turns.
+
+The switch is one command, and it is non-destructive:
+
+```bash
+recall claude sync
+# turns off the built-in auto-memory, installs the hook, skill, and MCP,
+# and imports your existing .md memory (plus mem0 / Zep exports) into the graph
+```
+
+After that the agent reads from the graph and writes back to it on ordinary
+prompts, corrections supersede instead of stacking, and the same memory is
+shared across tools instead of trapped in one tool's file.
+
 ## How Recall compares
 
 The main design split in agent memory is how trust changes when new

--- a/integrations/claude/hooks/recall-session-start.py
+++ b/integrations/claude/hooks/recall-session-start.py
@@ -185,35 +185,57 @@ def prompt_digest(prompt: str, cwd: str) -> str:
     if not rel:
         return ""
 
-    # ids + titles only: strip the trailing [kind:id], keep a short id, and
-    # truncate what remains (which is title-first) so summaries do not bleed in.
+    # Danger sets: which cells are the SUPERSEDED side of a contradiction (the
+    # target after `->`) or are flagged stale. Used to mark a row only when the
+    # row ITSELF may not be current, so the dig call scales with real risk
+    # instead of crying wolf on every dense-graph supersession trail.
+    conflict_lines = secs.get("conflicts", [])
+    stale_lines = secs.get("stale_or_low_trust", [])
+    challenged_ids = set(re.findall(r"->([0-9a-f]{8})", " ".join(conflict_lines)))
+    stale_ids = set(re.findall(r"stale:([0-9a-f]{8})", " ".join(stale_lines)))
+
+    # ids + titles only: strip the trailing [kind:id], keep a short id, truncate
+    # the rest (title-first), and flag the row if the cell is itself stale/superseded.
     index = []
+    flagged = False
     for ln in rel[:5]:
         m = re.search(r"\[([a-z_]+):([0-9a-f]{8})[0-9a-f-]*\]\s*$", ln)
+        short = m.group(2) if m else ""
         cid = f"{m.group(1)}:{m.group(2)}" if m else ""
         body = re.sub(r"\s*\[[a-z_]+:[0-9a-f-]+\]\s*$", "", ln).lstrip("- ").strip()
-        index.append(f"- {_trim(body, 110)}" + (f"  [{cid}]" if cid else ""))
+        tag = ""
+        if short and short in stale_ids:
+            tag, flagged = "  [STALE]", True
+        elif short and short in challenged_ids:
+            tag, flagged = "  [SUPERSEDED?]", True
+        index.append(f"- {_trim(body, 110)}" + (f"  [{cid}]" if cid else "") + tag)
     if not index:
         return ""
 
     parts = ["[Recall mini-index for THIS prompt (ids + titles only). You now know what exists, so do not ask or assert blind:]"]
     parts += index
 
-    n_conf = len(secs.get("conflicts", []))
-    n_stale = len(secs.get("stale_or_low_trust", []))
-    flags = []
-    if n_conf:
-        flags.append(f"{n_conf} challenged")
-    if n_stale:
-        flags.append(f"{n_stale} stale/low-trust")
-    if flags:
-        parts.append("tripwires touching this topic: " + ", ".join(flags) + ".")
-
-    parts.append(
-        "This is awareness, NOT a substitute. For anything load-bearing, run "
-        'recall compile "<task>" for bodies, the full conflict trace, and calibration, '
-        "and use search / subgraph / recall cell show <id> to dig."
-    )
+    if flagged:
+        # A SHOWN row may not be current: reading its title alone is unsafe.
+        parts.append(
+            "DIG REQUIRED: a row above is marked [SUPERSEDED?] or [STALE]; its title may be out of date. "
+            'Run recall compile "<task>" and recall cell show <id> on it BEFORE you act on it.'
+        )
+    elif conflict_lines or stale_lines:
+        bits = []
+        if conflict_lines:
+            bits.append(f"{len(conflict_lines)} challenged")
+        if stale_lines:
+            bits.append(f"{len(stale_lines)} stale/low-trust")
+        parts.append(
+            "tripwires elsewhere on this topic (" + ", ".join(bits) + "). "
+            'If you act here, run recall compile "<task>" for the conflict trace first.'
+        )
+    else:
+        parts.append(
+            "This is awareness, not a substitute. For anything load-bearing, run "
+            'recall compile "<task>" for bodies and calibration, and search / subgraph / cell show to dig.'
+        )
     return "\n".join(parts)
 
 


### PR DESCRIPTION
## What
- Adds a README section, "A real substitute for built-in auto-memory", covering ambient parity via the per-prompt push, supersession-awareness a flat file cannot do, and the one-command non-destructive switch.
- Lands the danger-proportional dig cue in the per-prompt hook: shown rows that are themselves superseded or stale get marked, and the dig directive escalates to DIG REQUIRED only when a shown row is flagged.

## Note
Supersedes PR #17, which could not be cleanly merged after #16 was squash-merged (divergent hook history). The same hook change is here, rebased clean onto current main.