### PR TITLE
test: fix Windows CI (separator-agnostic globalDbPath assertion)

### DIFF
--- a/tests/claude-sync.test.ts
+++ b/tests/claude-sync.test.ts
@@ -85,7 +85,7 @@ describe("importAutoMemoryToGlobal", () => {
   });
 
   it("globalDbPath resolves under ~/.recall/db", () => {
-    assert.match(globalDbPath(), /\.recall\/db\/global\.sqlite3$/);
+    assert.match(globalDbPath(), /\.recall[\\/]db[\\/]global\.sqlite3$/);
   });
 });
 


### PR DESCRIPTION
globalDbPath uses path.join, so on Windows it returns backslash separators and the forward-slash-only regex in the test never matched, failing windows-latest CI. The regex now accepts either separator. No implementation change.