### PR TITLE
feat(hooks): dig backstop (Stop-hook enforcement of DIG REQUIRED)

### DIFF
--- a/integrations/claude/hooks/recall-session-start.py
+++ b/integrations/claude/hooks/recall-session-start.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""SessionStart + UserPromptSubmit hook for the Recall active-memory substrate.
+"""SessionStart + UserPromptSubmit + Stop hook for the Recall active-memory substrate.
 
-Two modes:
+Three modes:
 
   default (SessionStart): emit the standing directive plus a cheap 7d
     recent-activity summary, scoped to whichever Recall DB the current
@@ -18,12 +18,21 @@ Two modes:
     runs a real `recall compile` and keeps the deeper tooling (search, subgraph,
     cell expansion) in play. The push is the invitation, not the substitute.
 
+  --stop (Stop): the dig backstop. The push can flag a row DIG REQUIRED, but a
+    UserPromptSubmit hook cannot enforce the dig because it returns before the
+    model acts. So the push records the obligation as per-session state, and
+    this mode blocks the turn from ending until the transcript shows a real
+    Recall read during the turn. Single-shot and loop-guarded: it nudges once,
+    never hard-traps.
+
 Fail-open by design: any error, timeout, or missing dependency falls back to the
 directive alone. A prompt/session hook must never break submission. The
 per-prompt compile is given a hard 4s timeout because it runs on every prompt.
 """
+import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -154,7 +163,7 @@ def _trim(line: str, n: int) -> str:
     return (line[: n - 1] + "…") if len(line) > n else line
 
 
-def prompt_digest(prompt: str, cwd: str) -> str:
+def prompt_digest(prompt: str, cwd: str, flagged_out=None) -> str:
     """Build a MINI index of cells relevant to `prompt`: ids + titles only, plus
     a count of the tripwires (challenged / stale cells) touching the topic.
 
@@ -210,8 +219,12 @@ def prompt_digest(prompt: str, cwd: str) -> str:
         tag = ""
         if short and short in stale_ids:
             tag, flagged = "  [STALE]", True
+            if flagged_out is not None:
+                flagged_out.append(short)
         elif short and short in challenged_ids:
             tag, flagged = "  [SUPERSEDED?]", True
+            if flagged_out is not None:
+                flagged_out.append(short)
         index.append(f"- {_trim(body, 110)}" + (f"  [{cid}]" if cid else "") + tag)
     if not index:
         return ""
@@ -243,18 +256,136 @@ def prompt_digest(prompt: str, cwd: str) -> str:
     return "\n".join(parts)
 
 
+# ---------------------------------------------------------------------------
+# Dig backstop (Stop hook)
+# ---------------------------------------------------------------------------
+# The per-prompt push can flag a row DIG REQUIRED, but a UserPromptSubmit hook
+# cannot enforce the dig: it has already returned before the model acts. So the
+# push records the obligation as per-session state, and the Stop hook below
+# refuses to let the turn end until the transcript shows a real Recall read.
+# Single-shot + loop-guarded: it nudges once, never hard-traps.
+
+STATE_DIR = os.path.expanduser("~/.recall/.dig_pending")
+
+# A Recall READ inside a transcript tool_use line: CLI verbs or the MCP read tools.
+RECALL_READ_RE = re.compile(
+    r"recall\s+(?:compile|search|semantic|cell\s+show|subgraph|beliefs|maintenance)"
+    r"|recall_peek\.py"
+    r"|mcp__recall__recall_(?:compile|search|semantic|cell|subgraph|beliefs|status)",
+    re.IGNORECASE,
+)
+
+
+def _state_path(session_id: str) -> str:
+    if not session_id:
+        return ""
+    safe = hashlib.sha1(session_id.encode("utf-8")).hexdigest()[:16]
+    return os.path.join(STATE_DIR, safe + ".json")
+
+
+def _transcript_len(transcript_path: str) -> int:
+    try:
+        if transcript_path and os.path.exists(transcript_path):
+            with open(transcript_path, "r", encoding="utf-8", errors="ignore") as f:
+                return sum(1 for _ in f)
+    except Exception:
+        pass
+    return 0
+
+
+def write_pending_dig(data: dict, flagged_ids) -> None:
+    """Persist (when flagged) or clear (when not) this turn's dig obligation,
+    keyed by session id. Records the transcript length at submit time so the
+    Stop hook only scans tool calls made during this turn. Fail-open."""
+    path = _state_path(data.get("session_id") or "")
+    if not path:
+        return
+    try:
+        if flagged_ids:
+            os.makedirs(STATE_DIR, exist_ok=True)
+            payload = {
+                "ids": sorted(set(flagged_ids)),
+                "from_line": _transcript_len(data.get("transcript_path", "")),
+            }
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+        elif os.path.exists(path):
+            os.remove(path)  # no obligation this turn: clear any stale one
+    except Exception:
+        pass
+
+
+def did_dig(transcript_path: str, from_line: int) -> bool:
+    """True if a Recall READ tool call appears in transcript lines [from_line:].
+    Requires the line to be a tool_use so a prose mention does not count.
+    Fail-open: if the transcript cannot be read, return True (allow)."""
+    try:
+        if not transcript_path or not os.path.exists(transcript_path):
+            return True
+        with open(transcript_path, "r", encoding="utf-8", errors="ignore") as f:
+            lines = f.readlines()
+    except Exception:
+        return True
+    for raw in lines[max(0, from_line):]:
+        if "tool_use" in raw and RECALL_READ_RE.search(raw):
+            return True
+    return False
+
+
+def stop_backstop(data: dict) -> str:
+    """Return a block reason if the turn must not end yet, else "". The
+    obligation is consumed on read, so the backstop fires at most once per
+    flagged turn (a nudge with teeth, never a hard trap). Fail-open."""
+    if data.get("stop_hook_active"):
+        return ""  # already blocked once this cycle; never loop
+    path = _state_path(data.get("session_id") or "")
+    if not path or not os.path.exists(path):
+        return ""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except Exception:
+        return ""
+    try:
+        os.remove(path)  # single-shot: consume the obligation now
+    except Exception:
+        pass
+    ids = state.get("ids") or []
+    if not ids:
+        return ""
+    if did_dig(data.get("transcript_path", ""), int(state.get("from_line", 0) or 0)):
+        return ""
+    shown = ", ".join(ids[:5])
+    return (
+        "DIG REQUIRED fired this turn on superseded/stale Recall cell(s): "
+        f"{shown}. The turn ended without reading them. Run "
+        'recall compile "<task>" (or recall cell show <id>) on the flagged '
+        "cell(s), and correct anything asserted from a stale row, before finishing."
+    )
+
+
 def main() -> int:
+    # --stop:   dig backstop (block the turn end until a flagged row was dug).
     # --prompt: per-prompt push (directive + mini relevance index).
-    # default: full SessionStart payload (directive + 7d recent-activity diff).
-    prompt_mode = "--prompt" in sys.argv[1:]
-    event = "UserPromptSubmit" if prompt_mode else "SessionStart"
+    # default:  full SessionStart payload (directive + 7d recent-activity diff).
+    argv = sys.argv[1:]
     data = read_hook_input()
+
+    if "--stop" in argv:
+        reason = stop_backstop(data)
+        print(json.dumps({"decision": "block", "reason": reason} if reason else {}))
+        return 0
+
+    prompt_mode = "--prompt" in argv
+    event = "UserPromptSubmit" if prompt_mode else "SessionStart"
 
     ctx = DIRECTIVE
     if prompt_mode:
-        digest = prompt_digest(data.get("prompt", ""), data.get("cwd", ""))
+        flagged_ids: list = []
+        digest = prompt_digest(data.get("prompt", ""), data.get("cwd", ""), flagged_ids)
         if digest:
             ctx = digest + "\n\n" + DIRECTIVE
+        write_pending_dig(data, flagged_ids)
     else:
         summary = recent_summary()
         if summary:

--- a/integrations/claude/hooks/test_dig_backstop.py
+++ b/integrations/claude/hooks/test_dig_backstop.py
@@ -1,0 +1,130 @@
+"""Tests for the dig backstop (Stop hook) in recall-session-start.py.
+
+The hook filename has a hyphen, so it is loaded by path rather than imported.
+Run: python3 integrations/claude/hooks/test_dig_backstop.py
+"""
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+HOOK = Path(__file__).with_name("recall-session-start.py")
+
+
+def load_hook(state_dir):
+    spec = importlib.util.spec_from_file_location("recall_hook_under_test", HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.STATE_DIR = state_dir  # redirect state off the real ~/.recall
+    return mod
+
+
+def _cli_read():
+    return json.dumps({"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "name": "Bash", "input": {"command": 'recall compile "x"'}}]}})
+
+
+def _mcp_read():
+    return json.dumps({"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "name": "mcp__recall__recall_compile", "input": {"task": "x"}}]}})
+
+
+def _prose_mention():
+    return json.dumps({"type": "assistant", "message": {"content": [
+        {"type": "text", "text": "I will run recall compile in a moment"}]}})
+
+
+def _noise():
+    return json.dumps({"type": "user", "message": {"content": "hello"}})
+
+
+class DigBackstopTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.h = load_hook(os.path.join(self.tmp, "dig_pending"))
+        self.tpath = os.path.join(self.tmp, "transcript.jsonl")
+
+    def _write(self, lines):
+        with open(self.tpath, "w", encoding="utf-8") as f:
+            for ln in lines:
+                f.write(ln + "\n")
+
+    def _data(self, **extra):
+        d = {"session_id": "sess-1", "transcript_path": self.tpath}
+        d.update(extra)
+        return d
+
+    # --- did_dig: a real read counts, a prose mention does not ---
+    def test_did_dig_finds_cli_read(self):
+        self._write([_noise(), _cli_read()])
+        self.assertTrue(self.h.did_dig(self.tpath, 0))
+
+    def test_did_dig_finds_mcp_read(self):
+        self._write([_noise(), _mcp_read()])
+        self.assertTrue(self.h.did_dig(self.tpath, 0))
+
+    def test_did_dig_ignores_prose_mention(self):
+        self._write([_noise(), _prose_mention()])
+        self.assertFalse(self.h.did_dig(self.tpath, 0))
+
+    def test_did_dig_respects_from_line(self):
+        # a read that happened before the turn boundary must not count
+        self._write([_cli_read(), _prose_mention()])
+        self.assertFalse(self.h.did_dig(self.tpath, 1))
+
+    def test_did_dig_failopen_on_missing_file(self):
+        self.assertTrue(self.h.did_dig(os.path.join(self.tmp, "nope"), 0))
+
+    # --- stop_backstop: block only when flagged and not dug ---
+    def test_blocks_when_flagged_and_not_dug(self):
+        self._write([_noise(), _noise()])
+        self.h.write_pending_dig(self._data(), ["aabbccdd"])
+        self.assertTrue(os.path.exists(self.h._state_path("sess-1")))
+        self._write([_noise(), _noise(), _prose_mention()])
+        reason = self.h.stop_backstop(self._data())
+        self.assertIn("DIG REQUIRED", reason)
+        self.assertIn("aabbccdd", reason)
+
+    def test_single_shot_consumes_obligation(self):
+        self._write([_noise(), _noise()])
+        self.h.write_pending_dig(self._data(), ["aabbccdd"])
+        self._write([_noise(), _noise(), _prose_mention()])
+        self.h.stop_backstop(self._data())            # blocks and consumes
+        self.assertFalse(os.path.exists(self.h._state_path("sess-1")))
+        self.assertEqual(self.h.stop_backstop(self._data()), "")  # nothing left
+
+    def test_allows_when_dug(self):
+        self._write([_noise(), _noise()])
+        self.h.write_pending_dig(self._data(), ["aabbccdd"])
+        self._write([_noise(), _noise(), _cli_read()])
+        self.assertEqual(self.h.stop_backstop(self._data()), "")
+
+    def test_allows_when_no_pending(self):
+        self.assertEqual(self.h.stop_backstop(self._data()), "")
+
+    def test_unflagged_turn_clears_pending(self):
+        self.h.write_pending_dig(self._data(), ["aabbccdd"])
+        self.h.write_pending_dig(self._data(), [])     # no flags this turn
+        self.assertFalse(os.path.exists(self.h._state_path("sess-1")))
+
+    def test_loop_guard_allows_when_stop_hook_active(self):
+        self._write([_noise(), _noise()])
+        self.h.write_pending_dig(self._data(), ["aabbccdd"])
+        self._write([_noise(), _noise(), _prose_mention()])
+        self.assertEqual(self.h.stop_backstop(self._data(stop_hook_active=True)), "")
+
+    def test_no_session_id_is_noop(self):
+        self.h.write_pending_dig({"transcript_path": self.tpath}, ["aabbccdd"])
+        self.assertEqual(self.h.stop_backstop({"transcript_path": self.tpath}), "")
+
+    # --- prompt_digest collects flagged ids via the out-list (no binary needed) ---
+    def test_prompt_digest_failopen_short_prompt(self):
+        flagged = []
+        self.assertEqual(self.h.prompt_digest("hi", "", flagged), "")
+        self.assertEqual(flagged, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/run-python-tests.mjs
+++ b/scripts/run-python-tests.mjs
@@ -50,7 +50,11 @@ if (!python) {
   process.exit(0);
 }
 
-for (const script of ["python/tests/toolkit_unit_tests.py", "python/hooks/test_hooks.py"]) {
+for (const script of [
+  "python/tests/toolkit_unit_tests.py",
+  "python/hooks/test_hooks.py",
+  "integrations/claude/hooks/test_dig_backstop.py",
+]) {
   const result = spawnSync(python, [script], { stdio: "inherit", env });
   if (result.status !== 0) {
     process.exit(result.status ?? 1);

--- a/src/core/claude-integration.ts
+++ b/src/core/claude-integration.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
  *
  * Idempotently installs (and on re-run, refreshes to the bundled "best
  * functional version") everything that makes a Claude Code agent adopt Recall:
- *   1. the consult-recall hook script (SessionStart + UserPromptSubmit),
+ *   1. the consult-recall hook script (SessionStart + UserPromptSubmit + Stop),
  *   2. the recall skill,
  *   3. the recall MCP server registration (user scope, ~/.claude.json),
  *   4. CLAUDE_CODE_DISABLE_AUTO_MEMORY=1 so Recall is not shadowed by Claude
@@ -68,10 +68,11 @@ export interface ClaudeIntegrationStatus {
 // Pure helpers (unit-tested; no filesystem access)
 // ---------------------------------------------------------------------------
 
-/** The canonical SessionStart + UserPromptSubmit hook groups for a given script path. */
+/** The canonical SessionStart + UserPromptSubmit + Stop hook groups for a given script path. */
 export function recallHookGroups(hookCommandPath: string): {
   SessionStart: unknown;
   UserPromptSubmit: unknown;
+  Stop: unknown;
 } {
   const q = JSON.stringify(hookCommandPath);
   return {
@@ -80,6 +81,9 @@ export function recallHookGroups(hookCommandPath: string): {
     },
     UserPromptSubmit: {
       hooks: [{ type: "command", command: `python3 ${q} --prompt`, timeout: 10 }],
+    },
+    Stop: {
+      hooks: [{ type: "command", command: `python3 ${q} --stop`, timeout: 10 }],
     },
   };
 }
@@ -107,7 +111,7 @@ export function mergeSettings(
   const groups = recallHookGroups(opts.hookCommandPath);
 
   const hooks: Record<string, unknown> = { ...((next.hooks as Record<string, unknown>) ?? {}) };
-  for (const event of ["SessionStart", "UserPromptSubmit"] as const) {
+  for (const event of ["SessionStart", "UserPromptSubmit", "Stop"] as const) {
     const prev = Array.isArray(hooks[event]) ? (hooks[event] as unknown[]) : [];
     const withoutRecall = prev.filter((g) => !isRecallGroup(g));
     const nextArr = [...withoutRecall, groups[event]];

--- a/tests/claude-integration.test.ts
+++ b/tests/claude-integration.test.ts
@@ -16,9 +16,9 @@ import {
 const HOOK = "/home/u/.claude/hooks/recall-session-start.py";
 
 describe("mergeSettings", () => {
-  it("injects both hook events and the auto-memory env var into an empty config", () => {
+  it("injects all three hook events and the auto-memory env var into an empty config", () => {
     const { next, changed } = mergeSettings({}, { hookCommandPath: HOOK, disableAutoMemory: true });
-    assert.deepEqual(changed.sort(), ["env.CLAUDE_CODE_DISABLE_AUTO_MEMORY", "hooks.SessionStart", "hooks.UserPromptSubmit"].sort());
+    assert.deepEqual(changed.sort(), ["env.CLAUDE_CODE_DISABLE_AUTO_MEMORY", "hooks.SessionStart", "hooks.UserPromptSubmit", "hooks.Stop"].sort());
     assert.equal((next.env as Record<string, string>).CLAUDE_CODE_DISABLE_AUTO_MEMORY, "1");
     const ss = (next.hooks as Record<string, unknown[]>).SessionStart;
     assert.equal(ss.length, 1);
@@ -86,11 +86,13 @@ describe("upsertMcpServer", () => {
 });
 
 describe("recallHookGroups", () => {
-  it("uses --prompt for UserPromptSubmit and the bare command for SessionStart", () => {
+  it("uses --prompt for UserPromptSubmit, --stop for Stop, and the bare command for SessionStart", () => {
     const g = recallHookGroups(HOOK);
     assert.match(JSON.stringify(g.SessionStart), /recall-session-start\.py/);
-    assert.doesNotMatch(JSON.stringify(g.SessionStart), /--prompt/);
+    assert.doesNotMatch(JSON.stringify(g.SessionStart), /--prompt|--stop/);
     assert.match(JSON.stringify(g.UserPromptSubmit), /--prompt/);
+    assert.match(JSON.stringify(g.Stop), /--stop/);
+    assert.doesNotMatch(JSON.stringify(g.Stop), /--prompt/);
   });
 });
 


### PR DESCRIPTION
Closes the one soft spot in the push -> dig -> firewalled-write loop: the dig was behavioral with no structural backstop. A UserPromptSubmit hook returns before the model acts, so enforcement has to live in a Stop hook.

How it works:
- the per-prompt push records a per-session dig obligation when it flags a row DIG REQUIRED (superseded/stale), plus the transcript length at submit time
- a new --stop mode blocks the turn from ending until the transcript shows a real Recall read made during the turn (a tool_use compile/search/cell-show/MCP read, not a prose mention)
- single-shot (the obligation is consumed on first evaluation) and loop-guarded (honors stop_hook_active), so it nudges at most once and can never hard-trap; fail-open on any error

Registration: recallHookGroups now includes the Stop group, installed by recall claude sync.

Tests: 13 Python unit tests (did_dig boundary/prose/mcp/fail-open, single-shot consume, loop guard, no-session no-op, clear-on-unflagged) wired into test:python; TS tests cover the Stop registration and the --stop command. Local: TS 229/229, Python 27/27 + 13.

Docs and the 0.3.0 release follow in a second PR.