### PR TITLE
docs: 0.3.0 documentation refresh + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-21
+
 ### Security
 
 - **Secret firewall broadened** (`src/core/firewall.ts`): an adversarial stress
@@ -36,6 +38,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Claude Code per-prompt push and dig backstop**
+  (`integrations/claude/hooks/recall-session-start.py`): the consult-Recall hook
+  now runs in three modes, all installed by `recall claude sync`. SessionStart
+  emits the directive plus a 7-day activity summary. UserPromptSubmit
+  (`--prompt`) is the push: it injects a MINI index of the cells relevant to the
+  prompt (ids and titles plus tripwire counts), deliberately incomplete so the
+  agent still runs a real `recall compile`. The danger-proportional dig marks a
+  shown row `[SUPERSEDED?]` or `[STALE]` only when that row is itself the
+  superseded or stale target, escalating to `DIG REQUIRED` only then, so it does
+  not cry wolf. Stop (`--stop`) is the backstop: it records the per-session dig
+  obligation and blocks the turn from ending until the transcript shows a real
+  Recall read, single-shot and loop-guarded so it nudges once and never
+  hard-traps. Covered by `integrations/claude/hooks/test_dig_backstop.py`.
+- **`trend` program operation** (`src/core/programs.ts`): finite-difference
+  calculus over a program's run history. Each run appends the bundle's current
+  value to a sliding window; the operation reports direction, slope, and
+  acceleration and trips on a sustained directional streak or a slope past
+  `delta`. Where `watch` asks whether a value moved, `trend` asks which way it
+  has been moving and how fast.
+- **Mem0 and Zep importers** (`recall import mem0|zep`): migrate an exported
+  Mem0 or Zep store into Recall as calibrated cells through the shared import
+  core. The Zep adapter reconstructs supersession from bi-temporal history (an
+  invalidated fact is superseded by its replacement via a `contradicts` edge).
+  Dry-run by default; `--apply` writes.
+- **`recall import local`**: lift global or cross-cutting cells into the
+  per-project database that the current directory routes to, so memory written
+  before a project was registered moves into its own graph. Dry-run by default.
 - **Release-readiness surface**: `recall version` now reports the package
   version shared by the CLI and MCP `initialize`; `recall export` /
   `recall import --json ... [--force]` provide a portable `recall.export.v1`
@@ -269,6 +298,7 @@ memory.
   hook, PreToolUse guard) with rollout guidance and longitudinal
   metrics interpretation.
 
-[Unreleased]: https://github.com/H-XX-D/recall-memory-substrate/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/H-XX-D/recall-memory-substrate/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/H-XX-D/recall-memory-substrate/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/H-XX-D/recall-memory-substrate/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/H-XX-D/recall-memory-substrate/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -321,9 +321,10 @@ recall codex sync      # OpenAI Codex
 recall claude status   # report which pieces are installed (codex status likewise)
 ```
 
-**Claude Code** (`recall claude sync`) installs a SessionStart/UserPromptSubmit
-hook that nudges the agent to consult Recall, copies the recall skill into
-`~/.claude/skills/`, registers the recall MCP server in `~/.claude.json`, and
+**Claude Code** (`recall claude sync`) installs the three-mode consult-Recall
+hook (SessionStart, UserPromptSubmit, and Stop, detailed below), copies the
+recall skill into `~/.claude/skills/`, registers the recall MCP server in
+`~/.claude.json`, and
 sets `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` so Recall is the durable memory layer
 instead of Claude Code's built-in note memory (keep native auto-memory, and skip
 the import below, with `RECALL_KEEP_AUTOMEMORY=1`; revert with `recall claude
@@ -336,6 +337,26 @@ and supersedes a changed file's prior version via a `contradicts` edge. To run
 that import on its own (for example to preview it first), use `recall import
 auto-memory [--root path] [--project name] [--apply] [--db path]` (dry-run by
 default; pass `--apply` to write).
+
+The hook runs in three modes, and together they are the closed loop that keeps
+an agent on Recall:
+
+- **SessionStart** emits the standing directive plus a short summary of what
+  changed in the graph in the last 7 days, scoped to the project the current
+  directory routes to.
+- **UserPromptSubmit** is the push. Before each prompt reaches the model, it
+  injects a mini index of the cells relevant to that prompt: ids and titles
+  only, plus a count of the tripwires (challenged or stale cells) on the topic.
+  It is deliberately incomplete, so the agent still runs a real `recall compile`
+  instead of treating the index as the answer. The dig is danger-proportional: a
+  shown row is marked `[SUPERSEDED?]` or `[STALE]` only when that row is itself
+  the superseded or stale cell, and it escalates to `DIG REQUIRED` only then, so
+  it does not cry wolf on every prompt.
+- **Stop** is the backstop. When a row was flagged `DIG REQUIRED`, this mode
+  blocks the turn from ending until the transcript shows the agent actually read
+  the flagged cell, then steps out of the way. It is single-shot and
+  loop-guarded, so it nudges once and never traps a turn, and it fails open on
+  any error.
 
 **Codex** (`recall codex sync`) copies the recall skill into
 `~/.codex/skills/`, registers the recall MCP server under `[mcp_servers.recall]`

--- a/docs/06_ADVANCED_GRAPH_OPERATIONS.md
+++ b/docs/06_ADVANCED_GRAPH_OPERATIONS.md
@@ -49,6 +49,13 @@ arbitrary JavaScript. The deterministic operations are:
   across distinct actors by default (`params.role` filters eligible
   members). A contradicted approver's approval stops counting. Quorum runs
   always derive their attestation.
+- `trend`: finite-difference calculus over the program's run history. Each run
+  appends the bundle's current value to a sliding window; the operation reports
+  direction, slope, and acceleration and trips on a sustained directional streak
+  or a slope past `params.delta`. Where `watch` asks whether a value moved,
+  `trend` asks which way it has been moving and how fast, so a bundle whose
+  effective confidence is quietly eroding over many runs trips before it ever
+  crosses a hard threshold.
 
 `--derive` converts operation output into a strict witness proposal and
 admits it through the normal write path, producing a rollbackable

--- a/docs/11_INSTALLATION.md
+++ b/docs/11_INSTALLATION.md
@@ -86,7 +86,7 @@ every update) and backs up your config before editing.
 
 ```bash
 recall claude sync     # installs the recall skill + MCP server + the
-                       # SessionStart/UserPromptSubmit consult-Recall hook, and sets
+                       # three-mode consult-Recall hook (push + dig backstop), and sets
                        # CLAUDE_CODE_DISABLE_AUTO_MEMORY=1 so Recall is THE memory layer
 recall claude status   # report which pieces are installed
 recall claude enable-auto-memory   # revert: re-enable Claude's native note-memory
@@ -94,7 +94,10 @@ recall claude enable-auto-memory   # revert: re-enable Claude's native note-memo
 
 Keep native auto-memory during sync with `RECALL_KEEP_AUTOMEMORY=1`. Touches
 `~/.claude/skills/recall/`, `~/.claude.json` (MCP), and `~/.claude/settings.json`
-(hook + env), and nothing else.
+(hook + env), and nothing else. The hook runs in three modes (SessionStart
+directive, the UserPromptSubmit push with a danger-proportional dig, and the
+Stop dig backstop that blocks a turn from ending until a flagged cell is read);
+see [`17_ENFORCING_USAGE.md`](17_ENFORCING_USAGE.md) for what each mode does.
 
 Bring your existing Claude Code auto-memory along:
 

--- a/docs/12_SECRETS_SIDE_GRAPH.md
+++ b/docs/12_SECRETS_SIDE_GRAPH.md
@@ -20,6 +20,28 @@ Secrets side graph.
 - Reading a secret requires the password again.
 - Passwords should be passed through stdin, not command-line arguments.
 
+## The admission firewall
+
+The rejection in the first rule is enforced by `src/core/firewall.ts`, which
+screens every write proposal before admission and refuses content that matches a
+known secret shape:
+
+- vendor key prefixes (for example Stripe `sk_live_` / `rk_live_`, AWS secret
+  access keys),
+- private-key blocks (`-----BEGIN ... PRIVATE KEY-----`),
+- secret-named assignments (`password:`, `api_key=`, `client_secret=`, and the
+  like, where a six-or-more-character value follows),
+- `KEY=value` env dumps whose key name itself reads as a secret (for example
+  `export DB_PASSWORD=...`),
+
+and it rejects outright any proposal marked `policy.sensitivity: "secret"`. It is
+a high-recall heuristic backstop, not a guarantee: it stops the common accidents
+(an agent pasting a live credential into memory), but it cannot catch a secret
+that does not look like one, so a bare high-entropy string with no telltale name
+will pass. Treat it as the net that keeps obvious leaks out of the plaintext
+graph, and put anything you actually need to keep in the encrypted side graph
+below.
+
 ## CLI
 
 Save:

--- a/docs/17_ENFORCING_USAGE.md
+++ b/docs/17_ENFORCING_USAGE.md
@@ -32,6 +32,34 @@ Four real causes, each addressable by a different technique:
    text directly doesn't. At the margin, the path of least resistance is
    to skip the tool call.
 
+## The shipped path: `recall claude sync`
+
+The techniques below are the portable building blocks. The product wires them
+into one installed hook, `integrations/claude/hooks/recall-session-start.py`,
+put in place by `recall claude sync`. It runs in three modes and is the closed
+loop in practice:
+
+- **SessionStart** emits the operating directive plus a 7-day activity summary.
+- **UserPromptSubmit (`--prompt`)** is the push (Technique 1, productized): a
+  mini index of the cells relevant to the prompt, ids and titles plus tripwire
+  counts, deliberately incomplete so the agent still runs a real `recall
+  compile`. The dig is danger-proportional: a row is marked `[SUPERSEDED?]` or
+  `[STALE]` only when it is itself the superseded or stale cell, escalating to
+  `DIG REQUIRED` only then.
+- **Stop (`--stop`)** is the dig backstop, the one structural enforcement point
+  in the soft loop. When a row was flagged `DIG REQUIRED`, it blocks the turn
+  from ending until the transcript shows the agent actually read the flagged
+  cell. It is single-shot and loop-guarded (it nudges once, never hard-traps)
+  and fails open on any error. This closes the gap that made the dig a
+  suggestion: the push and the firewalled write are structural, but the dig
+  itself was behavioral until this mode gave it a backstop.
+
+The `.sample` templates in `python/hooks/` documented below are the lower-level,
+runtime-agnostic version of the same ideas (and the PreToolUse guard, Technique
+4, is hard enforcement the shipped hook does not install by default). Use
+`recall claude sync` for Claude Code; use the templates to wire another runtime
+or to add hard enforcement.
+
 ## The fix: ambient presence, not stronger prompting
 
 Stronger system prompts don't work; they fade like the original. The
@@ -368,6 +396,7 @@ actually work" answerable instead of speculative.
 |---|---|
 | UserPromptSubmit injection (soft) | **shipped**: see Technique 1 |
 | Stop / SubagentStop reminder (soft) | **shipped**: see Technique 2 |
+| Stop dig backstop (`recall claude sync`, `--stop`) | **shipped**: blocks turn end until a `DIG REQUIRED` cell is read; single-shot, loop-guarded, fail-open |
 | System prompt operating contract | **shipped**: see Technique 3 |
 | PreToolUse guard / mandatory write-on-decision (hard) | **shipped**: see Technique 4 |
 | Compliance attestation per session | planned: hash chain of writes and reads for audit-trail use |

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,14 +106,14 @@ contributing requires.
 
 The CLI commands documented across these files map to actual implementations
 in [`../src/cli.ts`](../src/cli.ts). The current implemented surface (as of
-Recall 0.2.x) is:
+Recall 0.3.x) is:
 
 | Command | Subcommands | Documented in |
 |---|---|---|
 | `recall init` | None | 11, LLM_INTEGRATION |
 | `recall version` | None | 05, 11 |
 | `recall status` / `storage` | None | 11 |
-| `recall export` / `import` | `import`: `auto-memory` (also archive restore) | 05, 20 |
+| `recall export` / `import` | `import`: `auto-memory`, `mem0`, `zep`, `local` (also archive restore) | 05, 20 |
 | `recall tui` | None | 05 |
 | `recall validate` | None | 02, 05 |
 | `recall admit` / `write-propose` | None | 02, 05 |
@@ -170,13 +170,20 @@ enforcement is producing better outcomes over time. See
 ## Where things changed recently
 
 For changes since the last release, see [`../CHANGELOG.md`](../CHANGELOG.md).
-The headline unreleased changes: **effective confidence** (a live,
-graph-computed trust value on every cell, driving ranking and packets) and
-**active relations** (scored tripwire bundles plus `watch`/`drift`/`quorum`
-program operations; see
-[`06_ADVANCED_GRAPH_OPERATIONS.md`](06_ADVANCED_GRAPH_OPERATIONS.md)).
-Compile packets surface incoming challenges, per-cell `eff:` values, and
-the standing programs covering each selected cell.
+The headline changes in 0.3.0: the **Claude Code three-mode hook** installed by
+`recall claude sync` (the SessionStart directive, the UserPromptSubmit push with
+a danger-proportional dig, and the Stop dig backstop that blocks a turn from
+ending until a flagged cell is read; see
+[`17_ENFORCING_USAGE.md`](17_ENFORCING_USAGE.md)), the **`trend`** program
+operation (finite-difference calculus over a program's run history; see
+[`06_ADVANCED_GRAPH_OPERATIONS.md`](06_ADVANCED_GRAPH_OPERATIONS.md)), and
+**Mem0, Zep, and local importers** (`recall import mem0|zep|local`; see
+[`20_BACKUP_AND_RECOVERY.md`](20_BACKUP_AND_RECOVERY.md)). The 0.2.0 work this
+builds on: **effective confidence** (a live, graph-computed trust value on every
+cell, driving ranking and packets) and **active relations** (scored tripwire
+bundles plus `watch`/`drift`/`quorum` program operations). Compile packets
+surface incoming challenges, per-cell `eff:` values, and the standing programs
+covering each selected cell.
 
 For changes to the docs themselves, see git history on this directory.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recall-memory-substrate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Disciplined, operable memory for LLM agents \u2014 a local-first active memory substrate.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Phase two of the 0.3.0 release (the dig backstop feature landed in #25). Documentation only, plus the version bump.

- **CHANGELOG**: new 0.3.0 section covering the three-mode Claude hook and dig backstop, the trend program operation, and the mem0/zep/local importers; compare links updated.
- **README + docs/11_INSTALLATION**: recall claude sync is now documented as a three-mode hook (SessionStart directive + 7d activity, UserPromptSubmit push with a danger-proportional dig, Stop dig backstop).
- **docs/17_ENFORCING_USAGE**: reconciled with the shipped hook. It previously described only the older python/hooks/*.sample templates; added a "shipped path" section and marked the dig backstop shipped in the roadmap.
- **docs/06_ADVANCED_GRAPH_OPERATIONS**: documented the trend operation.
- **docs/12_SECRETS_SIDE_GRAPH**: documented the admission firewall (firewall.ts) honestly as a high-recall heuristic backstop, separate from the encrypted side graph.
- **docs/README**: index, implementation-status table, and recent-changes section refreshed to 0.3.x.
- **package.json**: 0.2.0 -> 0.3.0.

Docs flagged current and left untouched: 02, 07, 08, 09, 14, 18, 19, 20, PUSH_VS_PULL. After merge, tag v0.3.0 to cut the release.