### PR TITLE
docs: refresh 01_ARCHITECTURE for 0.3.x

### DIFF
--- a/docs/01_ARCHITECTURE.md
+++ b/docs/01_ARCHITECTURE.md
@@ -42,6 +42,21 @@ recall://cell/<project>/<category>/<type>/<subject>/<idea>/<timestamp>/<id>
 Facet tags are useful but not mandatory. Missing address facets are derived from
 scope, intent, title, topic, and provenance timestamp.
 
+Every cell carries two confidences: the immutable stated confidence the writer
+asserted, and a living effective confidence the graph computes on every read
+from incoming `supports`/`contradicts`/`concerns` and per-actor calibration
+(`clamp01(stated × actor-calibration + support − challenge)`). Ranking and
+compile packets use the effective value, so a contradicted cell sinks on its own
+with no model in the loop. Corrections supersede rather than overwrite: a new
+fact admitted with a `contradicts` edge demotes the prior cell and surfaces the
+resolution to later sessions instead of leaving two competing rows.
+
+Storage is per-project. The CLI wrapper routes each call to a SQLite database by
+walking up from the current directory through a registry of project roots (first
+match wins), falling back to a shared global database. Reads can federate the
+project and global databases with `--include-global`; writes always land in
+exactly one database.
+
 Primary node classes:
 
 - observation
@@ -132,8 +147,13 @@ Declared graph operations transform graph-local inputs into declared outputs.
 They must be versioned, sandboxed, permissioned, testable, and auditable.
 
 The current implementation supports multi-party graph relations and a sandboxed
-`recall.program.v1` runtime with deterministic `score`, `emit_witness`, and
-`tag_projection` operations. It does not execute arbitrary user code.
+`recall.program.v1` runtime with deterministic operations: `score`,
+`emit_witness`, `tag_projection`, `watch` (a standing reflex that trips when a
+bundle's effective confidence moves past a delta), `drift` (watch with member
+attribution), `quorum` (k-of-m sign-off as a graph object), and `trend`
+(finite-difference calculus over a program's run history: direction, slope, and
+acceleration). It does not execute arbitrary user code. See
+[`06_ADVANCED_GRAPH_OPERATIONS.md`](06_ADVANCED_GRAPH_OPERATIONS.md).
 
 Program, DAG, eval, and daemon outputs can be closed back into graph memory with
 explicit derivation mode. Derivation creates strict `recall.write.v1` proposals

--- a/docs/04_CONTEXT_COMPILER.md
+++ b/docs/04_CONTEXT_COMPILER.md
@@ -58,7 +58,7 @@ not a graph dump.
   cause tag as the dig heuristic: a challenged cell warrants a peek before
   you rely on it.
 - `standing_programs` lists the enabled programs (watch, drift, quorum,
-  score) covering each selected cell, with program and hyperedge handles.
+  trend, score) covering each selected cell, with program and hyperedge handles.
   When you write new evidence about a guarded cell, tie it into the listed
   bundle instead of orphaning it.
 - `conflicts` includes each selected cell's incoming `contradicts`/`concerns`

--- a/docs/05_CLI_TUI.md
+++ b/docs/05_CLI_TUI.md
@@ -72,6 +72,15 @@ dangling/unresolvable trust edges (dry-run by default; `--apply` deletes), and
 `recall calibration` reports per-actor Brier calibration: stated confidence
 versus contradiction outcomes.
 
+`recall claude sync` and `recall codex sync` wire Recall into Claude Code and
+Codex (the skill, the MCP server, and the displacement of native auto-memory).
+For Claude Code the hook runs in three modes: a SessionStart directive plus a
+7-day activity summary, a UserPromptSubmit push (a mini index of relevant cells
+with a danger-proportional dig), and a Stop dig backstop that blocks the turn
+from ending until a flagged cell is read. See
+[`17_ENFORCING_USAGE.md`](17_ENFORCING_USAGE.md) and
+[`11_INSTALLATION.md`](11_INSTALLATION.md).
+
 Routine memory writes are not a user workflow. Once Recall is running, the LLM
 submits strict write proposals through MCP `recall_write`, and admission/firewall
 decide what can land. CLI write/admit commands may exist for connector plumbing,

--- a/docs/15_LLM_MANAGED_MEMORY.md
+++ b/docs/15_LLM_MANAGED_MEMORY.md
@@ -27,6 +27,24 @@ recall_write
 It accepts a strict `recall.write.v1` proposal and returns the admission result.
 The LLM never writes raw graph rows.
 
+## Ambient push and the dig backstop
+
+Under the Claude Code integration (`recall claude sync`), the agent does not have
+to remember to read. Before each prompt, a hook pushes a mini index of the cells
+relevant to that prompt (ids, titles, and a count of the tripwires on the topic),
+so memory is ambient rather than something the agent must think to consult. The
+index is deliberately incomplete, which keeps the agent running a real
+`recall compile` for anything load-bearing instead of treating the index as the
+answer.
+
+The push marks a row `[SUPERSEDED?]` or `[STALE]` only when that row is itself
+the superseded or stale cell, escalating to `DIG REQUIRED` only then. When that
+fires, a Stop hook backstops it: the turn cannot end until the transcript shows
+the agent actually read the flagged cell. The push, the dig, and the firewalled
+write together are the closed loop, and the backstop is the one structural point
+that keeps the dig from being optional. See
+[`17_ENFORCING_USAGE.md`](17_ENFORCING_USAGE.md).
+
 ## User Role
 
 The user inspects, corrects, rolls back, reviews, or explicitly commands the

--- a/docs/LLM_INTEGRATION.md
+++ b/docs/LLM_INTEGRATION.md
@@ -202,7 +202,7 @@ Three packet signals govern how much to trust and where to dig:
   peek the challenger before relying on the claim.
 - `conflicts` lists each selected cell's incoming challengers with handles.
   A cell appearing here is contested, no matter how confident its line reads.
-- `standing_programs` lists the gates (watch, drift, quorum, score) covering
+- `standing_programs` lists the gates (watch, drift, quorum, trend, score) covering
   selected cells, with program and hyperedge handles. When writing new
   evidence about a guarded cell, reference the listed bundle so the gate
   sees it. Do not orphan evidence next to an existing gate.
@@ -289,6 +289,16 @@ announced once:
   (Edit, Write, destructive Bash) unless a recent Recall cell records the
   rationale for the change (`recall_pretooluse_guard.py.sample`).
 
-The soft layers nudge; the guard enforces. Setup, decision rules,
-configuration controls, and compliance auditing live in
+The soft layers nudge; the guard enforces.
+
+For Claude Code specifically, `recall claude sync` installs the productized
+version of the first two as one hook: a UserPromptSubmit push that injects a mini
+index of the cells relevant to the prompt (ids and titles plus tripwire counts,
+deliberately incomplete so you still run a real `recall_compile` for anything
+load-bearing), and a Stop dig backstop that blocks the turn from ending until the
+transcript shows a real Recall read when a row was flagged `DIG REQUIRED`. The
+`.sample` templates remain the runtime-agnostic building blocks and the hard
+PreToolUse guard.
+
+Setup, decision rules, configuration controls, and compliance auditing live in
 [Enforcing Recall Usage](17_ENFORCING_USAGE.md).

--- a/docs/LLM_SYSTEM_PROMPT.md
+++ b/docs/LLM_SYSTEM_PROMPT.md
@@ -70,6 +70,25 @@ At the end of substantial work:
 3. Prefer compact summaries that will compile well into future context packets.
 ```
 
+## Running under the Claude Code hook
+
+If you installed the integration with `recall claude sync`, three hooks already
+enforce most of the above, so the agent does not rely on prompt discipline alone:
+
+- **SessionStart** injects this directive plus a short summary of recent graph
+  activity.
+- **UserPromptSubmit** pushes a mini index of the cells relevant to each prompt
+  (ids and titles plus tripwire counts) before the model sees it. Treat the
+  index as a map, not the answer: run a real `recall compile` for anything
+  load-bearing, and especially when a row is marked `[SUPERSEDED?]`, `[STALE]`,
+  or `DIG REQUIRED`.
+- **Stop** is the dig backstop: if a row was flagged `DIG REQUIRED` and the turn
+  ends without a real Recall read, it blocks the turn until you read the flagged
+  cell. The simplest way to never hit it is to compile when the push flags
+  something.
+
+See [`17_ENFORCING_USAGE.md`](17_ENFORCING_USAGE.md).
+
 ## Where To Put This
 
 Put the pasteable instruction anywhere your LLM or agent framework stores


### PR DESCRIPTION
The architecture doc the 0.3.0 sweep skipped. Three stale spots fixed:

- Programs list was `score`/`emit_witness`/`tag_projection` only; added `watch`, `drift`, `quorum`, `trend` with a link to 06.
- Effective confidence (the living, graph-computed trust value that drives ranking) was absent; added to Graph Core, along with supersession-by-contradicts.
- Per-project + global database routing (CWD-based) was missing; added.

Docs only.