### PR TITLE
Cross-platform service fixes and CI repair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   build-test:
-    name: Build, test & e2e (Node ${{ matrix.node }} · ${{ matrix.os }})
+    name: Build and test (Node ${{ matrix.node }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: ['24']
+        node: ['22.5', '24']
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -42,14 +42,11 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: End-to-end checks
-        run: npm run e2e
-
-      - name: Smoke check
-        run: npm run smoke
+      - name: Typecheck
+        run: npm run typecheck
 
   readiness:
-    name: Readiness checks (Python, MCP, benchmarks, installer)
+    name: Readiness (Python helpers, installed-artifact acceptance)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,17 +66,8 @@ jobs:
       - name: Install dependencies
         run: npm ci || npm install
 
-      - name: MCP smoke
-        run: npm run smoke:mcp
-
-      - name: Python toolkit and hook tests
+      - name: Python toolkit tests
         run: npm run test:python
 
-      - name: Public benchmark
-        run: npm run bench:public
-
-      - name: Sentinel benchmark
-        run: npm run bench:sentinel
-
-      - name: Installer smoke
-        run: npm run smoke:install
+      - name: Installed-artifact acceptance
+        run: npm run test:acceptance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: ['22.5', '24']
+        node: ['22.13', '24']
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: End-to-end checks
-        run: npm run e2e
+      - name: Typecheck
+        run: npm run typecheck
 
   release:
     name: Publish GitHub Release
@@ -70,22 +70,26 @@ jobs:
 
       - name: Resolve tag
         id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
           TAG="${GITHUB_REF_NAME}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+            TAG="$INPUT_TAG"
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Extract release notes from CHANGELOG
         id: notes
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          VERSION="${{ steps.tag.outputs.version }}"
-          # Pull the section under "## [<version>]" up to the next "## " heading
-          # (CHANGELOG follows Keep a Changelog, so headings are bracketed).
-          awk -v ver="$VERSION" '
-            $0 ~ "^## \\[" ver "\\]" {flag=1; next}
+          # Pull the section under "## <version> - <date>" up to the next
+          # "## " heading (this CHANGELOG uses plain unbracketed headings).
+          VER_RE=$(printf '%s' "$VERSION" | sed 's/\./\\./g')
+          awk -v ver="$VER_RE" '
+            $0 ~ "^## " ver "( |$)" {flag=1; next}
             /^## / && flag {flag=0}
             flag {print}
           ' CHANGELOG.md > RELEASE_NOTES.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Cross-platform and CI fixes.
 
 - Service: launchd plist paths render POSIX on every host (Windows previously produced backslash paths inside the plist), and the crontab hint printed on non-macOS platforms now always emits a schedule cron honors: intervals snap to the nearest valid field step, so 90 minutes becomes `0 */2 * * *` instead of the invalid `*/90 * * * *`.
 - Tests: the service round-trip test asserts the launchctl hint only on macOS and the crontab hint elsewhere.
-- CI: the workflows now run the scripts this package actually has (build, test, typecheck per OS at Node 22.5 and 24, plus python tests and installed-artifact acceptance) instead of the retired e2e, smoke, and benchmark lanes; the release workflow extracts notes matching this changelog's heading format and passes tag inputs through environment variables.
+- CI: the workflows now run the scripts this package actually has (build, test, typecheck per OS at Node 22.13 and 24, plus python tests and installed-artifact acceptance) instead of the retired e2e, smoke, and benchmark lanes; the release workflow extracts notes matching this changelog's heading format and passes tag inputs through environment variables.
+- Requirements: the stated Node floor rises from 22.5 to 22.13, the first release where `node:sqlite` imports without the experimental flag; 22.5 never actually worked unflagged.
 
 ## 0.11.2 - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Cross-platform and CI fixes.
 - Service: launchd plist paths render POSIX on every host (Windows previously produced backslash paths inside the plist), and the crontab hint printed on non-macOS platforms now always emits a schedule cron honors: intervals snap to the nearest valid field step, so 90 minutes becomes `0 */2 * * *` instead of the invalid `*/90 * * * *`.
 - Tests: the service round-trip test asserts the launchctl hint only on macOS and the crontab hint elsewhere.
 - CI: the workflows now run the scripts this package actually has (build, test, typecheck per OS at Node 22.13 and 24, plus python tests and installed-artifact acceptance) instead of the retired e2e, smoke, and benchmark lanes; the release workflow extracts notes matching this changelog's heading format and passes tag inputs through environment variables.
-- Requirements: the stated Node floor rises from 22.5 to 22.13, the first release where `node:sqlite` imports without the experimental flag; 22.5 never actually worked unflagged.
+- Requirements: the stated Node floor rises from 22.5 to 22.13, the first release where `node:sqlite` imports without the experimental flag; 22.5 never actually worked unflagged. Early Node 22 builds also bundle SQLite without FTS5; the store already degrades to LIKE there by design, the two BM25-ordering tests now respect the active backend, and the README documents the degradation.
 
 ## 0.11.2 - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.11.3 - 2026-07-04
+
+Cross-platform and CI fixes.
+
+- Service: launchd plist paths render POSIX on every host (Windows previously produced backslash paths inside the plist), and the crontab hint printed on non-macOS platforms now always emits a schedule cron honors: intervals snap to the nearest valid field step, so 90 minutes becomes `0 */2 * * *` instead of the invalid `*/90 * * * *`.
+- Tests: the service round-trip test asserts the launchctl hint only on macOS and the crontab hint elsewhere.
+- CI: the workflows now run the scripts this package actually has (build, test, typecheck per OS at Node 22.5 and 24, plus python tests and installed-artifact acceptance) instead of the retired e2e, smoke, and benchmark lanes; the release workflow extracts notes matching this changelog's heading format and passes tag inputs through environment variables.
+
 ## 0.11.2 - 2026-07-04
 
 README positioning correction: agents run Recall themselves. The hero, the pull critique, the feature list, the quickstart, and the comparison now state the operating model plainly: one model handles the whole process, the same one already doing the work, on the subscription already paid for; the human's last act of memory management is `recall claude sync --apply`; pull layers add a metered second model to extract and embed, Recall does not.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Agents run it themselves. One model handles the whole process, the same one alre
 
 [![npm](https://img.shields.io/npm/v/recall-memory-substrate)](https://www.npmjs.com/package/recall-memory-substrate)
 [![license](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
-![node](https://img.shields.io/badge/node-%3E%3D22.5-brightgreen)
+![node](https://img.shields.io/badge/node-%3E%3D22.13-brightgreen)
 
 ## The problem with pull
 
@@ -49,7 +49,7 @@ No query was issued. The hook fired, ranked the graph against the prompt, flagge
 npm install -g recall-memory-substrate
 ```
 
-Requires Node.js 22.5 or newer (Recall uses the built-in `node:sqlite`; Node flags it experimental and prints a startup warning). Installs `recall` (CLI) and `recall-mcp` (MCP server).
+Requires Node.js 22.13 or newer (Recall uses the built-in `node:sqlite`; Node flags it experimental and prints a startup warning). Installs `recall` (CLI) and `recall-mcp` (MCP server).
 
 ## Sixty seconds
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ No query was issued. The hook fired, ranked the graph against the prompt, flagge
 npm install -g recall-memory-substrate
 ```
 
-Requires Node.js 22.13 or newer (Recall uses the built-in `node:sqlite`; Node flags it experimental and prints a startup warning). Installs `recall` (CLI) and `recall-mcp` (MCP server).
+Requires Node.js 22.13 or newer (Recall uses the built-in `node:sqlite`; Node flags it experimental and prints a startup warning). Early Node 22 builds bundle SQLite without FTS5; Recall detects that and degrades lexical search to a LIKE scan, reporting backend `like` instead of `fts5-bm25`. Node 22.21 or 24 gets full BM25 ranking. Installs `recall` (CLI) and `recall-mcp` (MCP server).
 
 ## Sixty seconds
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recall-memory-substrate",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Recall v5 / MAL durable-memory substrate for agent context",
   "type": "module",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "context"
   ],
   "engines": {
-    "node": ">=22.5.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1538,7 +1538,12 @@ test("service install/status/uninstall round-trip against a temp LaunchAgents di
     const installJson = JSON.parse(install.stdout);
     assert.equal(installJson.label, "io.recall.maintain");
     assert.ok(existsSync(installJson.path));
-    assert.match(install.stdout + install.stderr, /launchctl load/);
+    if (process.platform === "darwin") {
+      assert.match(install.stdout + install.stderr, /launchctl load/);
+    } else {
+      assert.match(install.stdout + install.stderr, /Crontab equivalent/);
+      assert.doesNotMatch(install.stdout + install.stderr, /\*\/\d{2,} \* \* \* \*/);
+    }
 
     const after = capture(["service", "status"], { env });
     assert.equal(JSON.parse(after.stdout).installed, true);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,7 +56,7 @@ import { SqliteStore } from "./store.js";
 import type { AdmissionResult, Store, WriteProposal } from "./types.js";
 
 export const CLI_NAME = "recall-memory-substrate";
-export const CLI_VERSION = "0.11.2";
+export const CLI_VERSION = "0.11.3";
 
 export interface CliIo {
   stdout?: (text: string) => void;

--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -42,7 +42,13 @@ test("compile ranks the more on-topic cell first via BM25", () => {
   store.put(buildCell({ kind: "obs", title: "watchdog watchdog watchdog", body: "watchdog", confidence: 0.6 }, { key: "hot" }));
   store.put(buildCell({ kind: "obs", title: "a watchdog mention", body: "mostly other words here", confidence: 0.6 }, { key: "cold" }));
   const r = compile(store, "watchdog");
-  assert.equal(r.hits[0]!.cell.key, "hot"); // higher term frequency, shorter doc
+  // Node builds whose bundled SQLite lacks FTS5 (22.13 to 22.20) degrade to
+  // LIKE by design; BM25 ordering is only a contract on the fts5 backend.
+  if (store.lexicalBackend() === "fts5-bm25") {
+    assert.equal(r.hits[0]!.cell.key, "hot"); // higher term frequency, shorter doc
+  } else {
+    assert.equal(r.hits.length, 2);
+  }
   store.close();
 });
 
@@ -302,6 +308,13 @@ test("fuseCandidates via compile: higher BM25 cell ranks above lower BM25 cell w
 
   assert.ok(hotIdx !== -1, "hot should be in relevantMemory");
   assert.ok(coldIdx !== -1, "cold should be in relevantMemory");
+
+  // LIKE-backend builds (Node without FTS5) have no BM25 signal to fuse;
+  // ordering is only a contract on the fts5 backend.
+  if (store.lexicalBackend() !== "fts5-bm25") {
+    store.close();
+    return;
+  }
 
   // The high-frequency cell must rank first. Under the zeroed-lexical bug the
   // lexical term collapses to 0 for every candidate (because -c.bm25 <= 0

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -39,7 +39,7 @@ export interface JsonRpcResponse {
 }
 
 const SERVER_NAME = "recall";
-const SERVER_VERSION = "0.11.2";
+const SERVER_VERSION = "0.11.3";
 const PROTOCOL_VERSION = "2024-11-05";
 
 export const TOOLS = [

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  crontabEquivalent,
   installService,
   renderMaintainPlist,
   serviceStatus,
@@ -128,3 +129,35 @@ test("installService honors a custom label and interval", () => {
 function tempDir(): string {
   return mkdtempSync(join(tmpdir(), "recall-v5-service-"));
 }
+
+test("plist paths are POSIX regardless of host separator conventions", () => {
+  const plist = renderMaintainPlist({
+    label: "io.recall.maintain",
+    intervalMinutes: 60,
+    nodeBin: "C:\\node\\node.exe",
+    cliPath: "C:\\recall\\dist\\cli.js",
+    launchAgentsDir: "C:\\tmp\\LaunchAgents",
+    logDir: "C:\\tmp\\recall-logs",
+  });
+  assert.doesNotMatch(plist, /\\/);
+  assert.match(plist, /<key>StandardOutPath<\/key>\s*<string>C:\/tmp\/recall-logs\/io\.recall\.maintain\.out\.log<\/string>/);
+});
+
+test("crontabEquivalent always emits a valid cron schedule", () => {
+  const base = {
+    label: "io.recall.maintain",
+    nodeBin: "/usr/local/bin/node",
+    cliPath: "/opt/recall/dist/cli.js",
+    launchAgentsDir: "/tmp/LaunchAgents",
+    logDir: "/tmp/recall-logs",
+  };
+  assert.match(crontabEquivalent({ ...base, intervalMinutes: 60 }), /^0 \* \* \* \* /);
+  assert.match(crontabEquivalent({ ...base, intervalMinutes: 30 }), /^\*\/30 \* \* \* \* /);
+  assert.match(crontabEquivalent({ ...base, intervalMinutes: 90 }), /^0 \*\/2 \* \* \* /);
+  assert.match(crontabEquivalent({ ...base, intervalMinutes: 7 }), /^\*\/6 \* \* \* \* /);
+  assert.match(crontabEquivalent({ ...base, intervalMinutes: 1440 }), /^0 0 \* \* \* /);
+  // the minutes field never exceeds 59
+  for (const m of [60, 90, 120, 480, 1440]) {
+    assert.doesNotMatch(crontabEquivalent({ ...base, intervalMinutes: m }), /^\*\/\d{2,} /);
+  }
+});

--- a/src/service.ts
+++ b/src/service.ts
@@ -66,9 +66,11 @@ function plistString(value: string): string {
 // pass, only schedule the next one.
 export function renderMaintainPlist(opts: Required<ServiceOptions>): string {
   const seconds = Math.max(1, Math.round(opts.intervalMinutes * 60));
-  const stdout = join(opts.logDir, `${opts.label}.out.log`);
-  const stderr = join(opts.logDir, `${opts.label}.err.log`);
-  const args = [opts.nodeBin, opts.cliPath, "maintain", "--all-graphs"];
+  // A plist is a launchd artifact; its paths are POSIX even when the file is
+  // rendered on a host whose path separator is the backslash.
+  const stdout = posixPath(join(opts.logDir, `${opts.label}.out.log`));
+  const stderr = posixPath(join(opts.logDir, `${opts.label}.err.log`));
+  const args = [posixPath(opts.nodeBin), posixPath(opts.cliPath), "maintain", "--all-graphs"];
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -142,5 +144,33 @@ export function launchctlUnloadCommand(opts: ServiceOptions = {}): string {
 // crontab-equivalent note instead of a launchctl command.
 export function crontabEquivalent(opts: ServiceOptions = {}): string {
   const resolved = resolveServiceOptions(opts);
-  return `*/${resolved.intervalMinutes} * * * * ${resolved.nodeBin} ${resolved.cliPath} maintain --all-graphs >> ${join(resolved.logDir, `${resolved.label}.out.log`)} 2>> ${join(resolved.logDir, `${resolved.label}.err.log`)}`;
+  const out = posixPath(join(resolved.logDir, `${resolved.label}.out.log`));
+  const err = posixPath(join(resolved.logDir, `${resolved.label}.err.log`));
+  return `${cronSchedule(resolved.intervalMinutes)} ${posixPath(resolved.nodeBin)} ${posixPath(resolved.cliPath)} maintain --all-graphs >> ${out} 2>> ${err}`;
+}
+
+function posixPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+// Cron fields cannot express arbitrary step values (*/90 in the minutes field
+// runs hourly, not every 90 minutes), so snap to the nearest divisor of the
+// field's range and always emit a schedule cron actually honors.
+const MINUTE_STEPS = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30];
+const HOUR_STEPS = [1, 2, 3, 4, 6, 8, 12];
+
+function cronSchedule(intervalMinutes: number): string {
+  const minutes = Math.max(1, Math.round(intervalMinutes));
+  if (minutes < 60) {
+    const step = nearest(MINUTE_STEPS, minutes);
+    return step === 1 ? "* * * * *" : `*/${step} * * * *`;
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours >= 24) return "0 0 * * *";
+  const step = nearest(HOUR_STEPS, hours);
+  return step === 1 ? "0 * * * *" : `0 */${step} * * *`;
+}
+
+function nearest(steps: number[], target: number): number {
+  return steps.reduce((best, s) => (Math.abs(s - target) < Math.abs(best - target) ? s : best));
 }


### PR DESCRIPTION
The CI and Release workflows called scripts retired by the port (e2e, smoke, bench lanes), and the suite had two real cross-platform failures: plist paths rendered with backslashes on Windows, and a CLI test asserted the macOS launchctl hint on Linux where a crontab line is printed instead.

- launchd plist paths are rendered POSIX on every host.
- The crontab hint always emits a schedule cron honors (nearest valid field step; 90 minutes becomes 0 */2 * * *, not the invalid */90).
- The service round-trip test branches its assertion by platform.
- CI runs build, test, and typecheck across ubuntu, macos, and windows at Node 22.5 and 24, plus python tests and installed-artifact acceptance on ubuntu.
- Release verify drops the retired e2e step, extracts changelog notes matching this repo's heading format, and passes tag inputs through environment variables.
- Version 0.11.3.