### PR TITLE
feat(scores): wire the actor-calibration and salience producers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+Two score producers that the effective and salience formulas already consumed but nothing fed are now wired, so both scores move from real signal instead of sitting at their neutral seed.
+
+- Actor calibration: `actors.ts` derives a writer's `ActorOutcome[]` from the store (a past write is contradicted if it was superseded or carries an incoming active `contradicts` edge, else survived), and `actorCalibrationFactor(store, actorId)` runs the existing Brier math over it. The CLI `admit`/`write-propose` path and the MCP `recall_write` tool derive the factor for the write's actor (keyed on `owner`, default `claude-code`) and pass it as `calibrationFactor`, so a proven-miscalibrated actor's new writes deflate at intake; the factor stays neutral (1) until the actor has at least 3 resolved outcomes. `admit()` itself is unchanged: it still consumes an injected factor, so the store-free library contract and its tests keep their neutral default.
+- Salience: a leaky accumulator, at last. `salienceDecay`/`salienceBump` in `scores.ts` (tau 30d, floor 0.05, gain 0.2); the operator tick leaks salience from a new `lastSalientAt` anchor toward the floor, distinct from the currency anchor (`updatedAt`) so a read reinforces attention without refreshing freshness, and pinned cells are exempt like currency. `SqliteStore.touchSalience(key, now)` is the one accumulation point (seed' = seed + (1-seed)*gain, updatedAt preserved); the MCP `recall_cell` tool bumps on agent retrieval. CLI `cell show` stays a pure read by design, so archive export/re-import round-trips remain idempotent.
+
 ## 0.12.0 - 2026-07-04
 
 Phase 6 of the subsystem port: the daily-driver loop. The hooks, python tooling, and skills that ran the live machine's session loop now speak the v5 schema and CLI, and the four 0.11 defects on that path are fixed, so a legacy install can cut over to this line with its memory migrated.

--- a/src/actors.test.ts
+++ b/src/actors.test.ts
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { SqliteStore } from "./store.js";
+import { buildCell } from "./build.js";
+import { actorCalibrationFactor, actorOutcomes } from "./actors.js";
+import { admit } from "./admission.js";
+import type { Cell } from "./types.js";
+
+// Build and store a cell owned by `actor` with a given confidence and key.
+function write(
+  store: SqliteStore,
+  actor: string,
+  key: string,
+  confidence: number,
+  extra: Partial<Cell> = {},
+): Cell {
+  const cell = { ...buildCell({ kind: "obs", title: key, body: "b", confidence, owner: actor }, { key }), ...extra };
+  store.put(cell);
+  return cell;
+}
+
+// A hard contradiction: an active cell by a critic pointing contradicts -> target.
+function contradict(store: SqliteStore, targetKey: string, key: string): void {
+  store.put(
+    buildCell(
+      { kind: "obs", title: key, body: "b", confidence: 0.8, owner: "critic", edges: [{ relation: "contradicts", target: targetKey }] },
+      { key },
+    ),
+  );
+}
+
+test("actorCalibrationFactor is neutral (1) below 3 resolved outcomes", () => {
+  const store = new SqliteStore(":memory:");
+  write(store, "alice", "a1", 0.9);
+  write(store, "alice", "a2", 0.9);
+  assert.equal(actorCalibrationFactor(store, "alice"), 1);
+  store.close();
+});
+
+test("all-survived history still carries the Brier penalty for hedged confidence", () => {
+  const store = new SqliteStore(":memory:");
+  write(store, "alice", "a1", 0.9);
+  write(store, "alice", "a2", 0.9);
+  write(store, "alice", "a3", 0.9);
+  // brier = mean((0.9 - 1)^2) = 0.01 -> factor 0.99
+  assert.ok(Math.abs(actorCalibrationFactor(store, "alice") - 0.99) < 1e-9);
+  store.close();
+});
+
+test("a confident writer who is repeatedly contradicted floors at 0.5", () => {
+  const store = new SqliteStore(":memory:");
+  write(store, "bob", "b1", 1);
+  write(store, "bob", "b2", 1);
+  write(store, "bob", "b3", 1);
+  contradict(store, "b1", "x1");
+  contradict(store, "b2", "x2");
+  contradict(store, "b3", "x3");
+  // brier = mean((1 - 0)^2) = 1 -> 1 - 1 = 0, floored to 0.5
+  assert.equal(actorCalibrationFactor(store, "bob"), 0.5);
+  store.close();
+});
+
+test("a superseded write counts as contradicted", () => {
+  const store = new SqliteStore(":memory:");
+  write(store, "carol", "c1", 1, { status: "superseded" });
+  write(store, "carol", "c2", 1, { status: "superseded" });
+  write(store, "carol", "c3", 1, { status: "superseded" });
+  assert.equal(actorCalibrationFactor(store, "carol"), 0.5);
+  store.close();
+});
+
+test("a soft concerns edge does NOT flip the outcome to contradicted", () => {
+  const store = new SqliteStore(":memory:");
+  write(store, "dana", "d1", 0.9);
+  write(store, "dana", "d2", 0.9);
+  write(store, "dana", "d3", 0.9);
+  store.put(
+    buildCell(
+      { kind: "obs", title: "concern", body: "b", confidence: 0.8, owner: "critic", edges: [{ relation: "concerns", target: "d1" }] },
+      { key: "cc1" },
+    ),
+  );
+  // still all survived -> 0.99, not the contradicted floor
+  assert.ok(Math.abs(actorCalibrationFactor(store, "dana") - 0.99) < 1e-9);
+  store.close();
+});
+
+test("outcomes are scoped to the actor and exclude the cell being written", () => {
+  const store = new SqliteStore(":memory:");
+  write(store, "erin", "e1", 0.9);
+  write(store, "erin", "e2", 0.9);
+  write(store, "erin", "e3", 0.9);
+  write(store, "someone-else", "z1", 0.1); // different actor, ignored
+  const scoped = actorOutcomes(store, "erin");
+  assert.equal(scoped.length, 3);
+  const excluding = actorOutcomes(store, "erin", { excludeKey: "e3" });
+  assert.equal(excluding.length, 2);
+  store.close();
+});
+
+test("the derived factor feeds admit and deflates a proven-miscalibrated actor's effective", () => {
+  const store = new SqliteStore(":memory:");
+  // frank overclaims (conf 1) and is contradicted three times.
+  write(store, "frank", "f1", 1);
+  write(store, "frank", "f2", 1);
+  write(store, "frank", "f3", 1);
+  contradict(store, "f1", "y1");
+  contradict(store, "f2", "y2");
+  contradict(store, "f3", "y3");
+
+  const factor = actorCalibrationFactor(store, "frank", { excludeKey: "f4" });
+  assert.equal(factor, 0.5); // floored
+
+  // The exact call the CLI/MCP make: derive the factor, feed it into R1.
+  // conf 0.6 stays under the 0.7 unsupported-confidence cap, so effective
+  // isolates the calibration effect: 0.6 * 0.5.
+  const r = admit(
+    { kind: "obs", title: "f4", body: "new claim", confidence: 0.6, owner: "frank" },
+    { store, key: "f4", calibrationFactor: factor },
+  );
+  assert.ok(r.accepted);
+  assert.equal(r.cell!.scores.actorCalibration, 0.5);
+  assert.ok(Math.abs(r.cell!.scores.effective - 0.3) < 1e-9); // 0.6 * 0.5
+  assert.ok(r.attenuations.some((a) => a.includes("calibration")));
+  store.close();
+});
+
+test("a fresh actor with no track record admits at neutral calibration", () => {
+  const store = new SqliteStore(":memory:");
+  const factor = actorCalibrationFactor(store, "grace");
+  assert.equal(factor, 1);
+  const r = admit(
+    { kind: "obs", title: "g1", body: "b", confidence: 0.7, owner: "grace" },
+    { store, key: "g1", calibrationFactor: factor },
+  );
+  assert.equal(r.cell!.scores.actorCalibration, 1);
+  assert.equal(r.cell!.scores.effective, 0.7);
+  store.close();
+});

--- a/src/actors.ts
+++ b/src/actors.ts
@@ -1,0 +1,50 @@
+// Actor calibration producer: the read side of R1 calibration. calibration.ts is
+// the pure Brier math; this module derives the ActorOutcome history it scores by
+// asking the store what later happened to an actor's past writes. The effective
+// formula already consumes actorCalibration (admission/operator); this is the
+// missing producer that turns a writer's track record into the factor it feeds.
+import { calibrationFactor } from "./calibration.js";
+import type { ActorOutcome, Store } from "./types.js";
+
+// A past write is judgeable once the graph has reacted to it: it was superseded,
+// or it carries an incoming *active* contradicts edge. Those are outcome 0
+// (contradicted); every other write by the actor is outcome 1 (survived/held).
+// A soft `concerns` edge does not flip the outcome; only a hard contradiction
+// or a supersession counts as the claim having been wrong.
+export function actorOutcomes(
+  store: Store,
+  actorId: string,
+  opts: { excludeKey?: string } = {},
+): ActorOutcome[] {
+  const outcomes: ActorOutcome[] = [];
+  for (const cell of store.all()) {
+    if (cell.provenance.producedBy !== actorId) continue;
+    if (opts.excludeKey && cell.key === opts.excludeKey) continue;
+    outcomes.push({
+      confidence: cell.scores.conf,
+      contradicted: cell.status === "superseded" || hasActiveContradiction(store, cell.key),
+    });
+  }
+  return outcomes;
+}
+
+function hasActiveContradiction(store: Store, key: string): boolean {
+  return store.neighbors(key).some(
+    (link) =>
+      link.direction === "in" &&
+      link.edge.relation === "contradicts" &&
+      link.cell.status === "active",
+  );
+}
+
+// The actor's standing calibration factor in [0.5, 1]. Neutral (1) until the
+// actor has at least 3 resolved outcomes (calibrationFactor's own floor for
+// "too little history to judge"). Pass excludeKey for the cell being written so
+// a write never calibrates against itself.
+export function actorCalibrationFactor(
+  store: Store,
+  actorId: string,
+  opts: { excludeKey?: string } = {},
+): number {
+  return calibrationFactor(actorOutcomes(store, actorId, opts));
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { platform } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { admit } from "./admission.js";
+import { actorCalibrationFactor } from "./actors.js";
 import {
   exportCellArchive,
   importAutoMemory,
@@ -198,7 +199,11 @@ export function runCli(argv: string[], options: RunCliOptions = {}): number {
       const proposal = readProposal(args);
       const store = openWriteStore(route.dbPath);
       try {
-        const result = admit(proposal, { store, now: options.now });
+        // Derive the actor's standing calibration factor from this store's
+        // history (buildCell keys producedBy on owner, default "claude-code")
+        // and feed it into R1. Neutral (1) until the actor has >= 3 outcomes.
+        const calibrationFactor = actorCalibrationFactor(store, proposal.owner ?? "claude-code");
+        const result = admit(proposal, { store, now: options.now, calibrationFactor });
         if (result.accepted && result.cell && !args.noGuidance) {
           const suggest = args.noSuggestPrograms
             ? false
@@ -371,6 +376,11 @@ export function runCli(argv: string[], options: RunCliOptions = {}): number {
       const target = args.command[subcommand === "show" ? 2 : 1];
       if (!target) throw new Error("cell show requires a key or handle");
       return withReadStore(args, route, env, (store) => {
+        // Deliberately does NOT bump salience: `cell show` is developer
+        // inspection and must stay a pure read (it runs between archive
+        // export and re-import, where a mutation would break round-trip
+        // idempotence). Retrieval reinforcement is the agent-facing recall_cell
+        // MCP tool's job, where a read genuinely is the agent's attention.
         outJson(out, inspectCell(store, target));
         return 0;
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./actors.js";
 export * from "./address.js";
 export * from "./adapters.js";
 export * from "./admission.js";

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -9,6 +9,7 @@
 import { analyzeMemory, memoryHealthToProposal } from "./analysis.js";
 import { compileContext, formatContextPacket } from "./compile.js";
 import { inspectCell, resolveCell } from "./cell-context.js";
+import { actorCalibrationFactor } from "./actors.js";
 import { admit } from "./admission.js";
 import { buildWriteGuidance } from "./guidance.js";
 import { semanticSearch } from "./semantic.js";
@@ -120,6 +121,11 @@ function callTool(name: string, args: Record<string, unknown>, store: Store): st
     case "recall_cell": {
       const ref = String(args.idOrAddress ?? args.id ?? "");
       const c = inspectCell(store, ref).cell;
+      // Retrieval bump: an agent pulling a cell into context is attention.
+      // SqliteStore-only, so it is a no-op on any read-only store.
+      if ("touchSalience" in store) {
+        (store as SqliteStore).touchSalience(c.key, new Date().toISOString());
+      }
       return JSON.stringify({
         id: c.key,
         handle: c.handle,
@@ -132,7 +138,11 @@ function callTool(name: string, args: Record<string, unknown>, store: Store): st
       });
     }
     case "recall_write": {
-      const r = admit(toProposal(args), { store });
+      const proposal = toProposal(args);
+      // Derive the actor's standing calibration factor from this store's history
+      // before R1 folds it into effective. Neutral until >= 3 resolved outcomes.
+      const calibrationFactor = actorCalibrationFactor(store, proposal.owner ?? "claude-code");
+      const r = admit(proposal, { store, calibrationFactor });
       const suggest = args.suggestPrograms === false ? false : args.suggestPrograms === true ? true : process.env.RECALL_SUGGEST_PROGRAMS !== "0";
       const guidance = r.accepted && r.cell ? buildWriteGuidance(store, r.cell, r, { suggestPrograms: suggest }) : undefined;
       return JSON.stringify({

--- a/src/operator.test.ts
+++ b/src/operator.test.ts
@@ -184,3 +184,44 @@ test("runOperatorCycle against a bare Store double still cycles, with ledger lef
   assert.equal(result.ticked, 1);
   assert.equal(result.ledger, undefined);
 });
+
+test("tick leaks salience from lastSalientAt toward the floor", () => {
+  const store = new SqliteStore(":memory:");
+  const c = buildCell(
+    { kind: "obs", title: "T", body: "b", confidence: 0.6 },
+    { key: "salc", now: "2026-01-01T00:00:00.000Z" },
+  );
+  store.put(c);
+  // 30 days idle from updatedAt (no lastSalientAt): salience decays below seed 0.5
+  tick(store, "2026-01-31T00:00:00.000Z");
+  const after = store.get("salc")!;
+  assert.ok(after.scores.salience < 0.5);
+  assert.ok(after.scores.salience >= 0.05); // stays above the floor
+  assert.equal(after.scores.salienceSeed, 0.5); // seed is the anchor, unchanged
+  store.close();
+});
+
+test("tick leaves salience at the seed when there is no idle time", () => {
+  const store = new SqliteStore(":memory:");
+  const c = buildCell(
+    { kind: "obs", title: "T", body: "b", confidence: 0.6 },
+    { key: "sal0", now: "2026-01-01T00:00:00.000Z" },
+  );
+  store.put(c);
+  tick(store, "2026-01-01T00:00:00.000Z"); // dt=0
+  assert.equal(store.get("sal0")?.scores.salience, 0.5);
+  store.close();
+});
+
+test("a pinned cell's salience does not leak", () => {
+  const store = new SqliteStore(":memory:");
+  const c = buildCell(
+    { kind: "obs", title: "T", body: "b", confidence: 0.6 },
+    { key: "salp", now: "2026-01-01T00:00:00.000Z" },
+  );
+  c.flags.pinned = true;
+  store.put(c);
+  tick(store, "2027-01-01T00:00:00.000Z"); // a year later
+  assert.equal(store.get("salp")?.scores.salience, 0.5);
+  store.close();
+});

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -5,7 +5,7 @@
 // neighbor effectives, then written, so a tick is order-independent.
 import { randomUUID } from "node:crypto";
 import type { AdmissionResult, Cell, Stability, Store, StoreStats } from "./types.js";
-import { currency, effectiveConfidence } from "./scores.js";
+import { currency, effectiveConfidence, salienceDecay } from "./scores.js";
 import { neighborMass } from "./mass.js";
 import { runStandingPrograms, type ProgramRun } from "./programs.js";
 import type { SqliteStore } from "./store.js";
@@ -61,6 +61,10 @@ function recompute(store: Store, cell: Cell, now: string): Cell {
       tau: TAU_DAYS[cell.stability],
       cFloor: 0.1,
     });
+    // Salience leaks from its own anchor (last retrieval, else updatedAt), so
+    // attention fades on idle without touching the currency/freshness anchor.
+    const dtSal = Math.max(0, (Date.parse(now) - Date.parse(cell.lastSalientAt ?? cell.updatedAt)) / DAY_MS);
+    scores.salience = salienceDecay({ seed: cell.scores.salienceSeed, dt: dtSal });
   }
   const m = neighborMass(store, cell.key);
   scores.effective = effectiveConfidence({

--- a/src/scores.test.ts
+++ b/src/scores.test.ts
@@ -1,6 +1,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { effectiveConfidence, currency } from "./scores.js";
+import {
+  effectiveConfidence,
+  currency,
+  salienceDecay,
+  salienceBump,
+  SALIENCE_FLOOR,
+  SALIENCE_TAU_DAYS,
+} from "./scores.js";
 
 test("effectiveConfidence with zero masses equals clamp01(stated*calibration)", () => {
   const stated = 0.8;
@@ -68,4 +75,24 @@ test("currency stays at c0 when dt=0 for any tau and floor", () => {
   for (const tau of [3650, 30, 7]) {
     assert.equal(currency({ c0: 0.7, dt: 0, tau, cFloor: 0.2 }), 0.7);
   }
+});
+
+test("salienceDecay returns the seed at dt=0 (no idle time, no leak)", () => {
+  assert.equal(salienceDecay({ seed: 0.5, dt: 0 }), 0.5);
+  assert.equal(salienceDecay({ seed: 0.9, dt: 0 }), 0.9);
+});
+
+test("salienceDecay leaks toward the floor over idle time", () => {
+  const one = salienceDecay({ seed: 0.5, dt: SALIENCE_TAU_DAYS }); // dt/tau = 1
+  assert.ok(Math.abs(one - (SALIENCE_FLOOR + (0.5 - SALIENCE_FLOOR) * Math.exp(-1))) < 1e-9);
+  const far = salienceDecay({ seed: 0.5, dt: SALIENCE_TAU_DAYS * 100 });
+  assert.ok(far >= SALIENCE_FLOOR && far - SALIENCE_FLOOR < 1e-3); // asymptotes to floor
+});
+
+test("salienceBump accumulates toward 1 with diminishing returns, clamped", () => {
+  const once = salienceBump(0.5); // 0.5 + 0.5*0.2 = 0.6
+  assert.ok(Math.abs(once - 0.6) < 1e-9);
+  const twice = salienceBump(once); // 0.6 + 0.4*0.2 = 0.68
+  assert.ok(Math.abs(twice - 0.68) < 1e-9);
+  assert.ok(salienceBump(1) <= 1 && salienceBump(0.999) <= 1); // never exceeds 1
 });

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -40,3 +40,35 @@ export function currency({
 }): number {
   return cFloor + (c0 - cFloor) * Math.exp(-dt / tau);
 }
+
+// Salience is attention, not freshness: it accrues on retrieval and leaks on
+// idle. SALIENCE_TAU_DAYS is the idle leak time-constant; SALIENCE_FLOOR is the
+// resting attention a never-retrieved cell settles toward; SALIENCE_GAIN is the
+// per-retrieval accumulator step in salienceBump.
+export const SALIENCE_TAU_DAYS = 30;
+export const SALIENCE_FLOOR = 0.05;
+export const SALIENCE_GAIN = 0.2;
+
+// Idle leak: salience = floor + (seed - floor) * exp(-dt/tau). At dt=0 returns
+// the seed (so a just-retrieved or brand-new cell holds its salience); as idle
+// time grows it decays toward the floor. Anchored to lastSalientAt so, like the
+// currency tick, it is idempotent and never compounds.
+export function salienceDecay({
+  seed,
+  dt,
+  tau = SALIENCE_TAU_DAYS,
+  floor = SALIENCE_FLOOR,
+}: {
+  seed: number;
+  dt: number;
+  tau?: number;
+  floor?: number;
+}): number {
+  return floor + (seed - floor) * Math.exp(-dt / tau);
+}
+
+// Retrieval bump: a leaky-accumulator step toward 1. seed' = seed + (1-seed)*gain,
+// clamped to [0, 1]. Diminishing returns as a cell is retrieved repeatedly.
+export function salienceBump(seed: number, gain = SALIENCE_GAIN): number {
+  return clamp01(seed + (1 - seed) * gain);
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -889,3 +889,39 @@ test("storageStats maximumCell.bytes counts true UTF-8 bytes, not characters, fo
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("touchSalience bumps salience and sets the anchor without refreshing updatedAt", () => {
+  const store = new SqliteStore(":memory:");
+  const cell = buildCell(
+    { kind: "obs", title: "attention", body: "b", confidence: 0.7 },
+    { key: "touch1", now: "2026-01-01T00:00:00.000Z" },
+  );
+  store.put(cell);
+
+  const bumped = store.touchSalience("touch1", "2026-02-01T00:00:00.000Z");
+  assert.ok(bumped);
+  assert.ok(Math.abs(bumped!.scores.salienceSeed - 0.6) < 1e-9); // 0.5 + 0.5*0.2
+  assert.equal(bumped!.scores.salience, bumped!.scores.salienceSeed);
+  assert.equal(bumped!.lastSalientAt, "2026-02-01T00:00:00.000Z");
+  assert.equal(bumped!.updatedAt, "2026-01-01T00:00:00.000Z"); // freshness untouched
+
+  const reread = store.get("touch1")!;
+  assert.ok(Math.abs(reread.scores.salienceSeed - 0.6) < 1e-9);
+  assert.equal(reread.lastSalientAt, "2026-02-01T00:00:00.000Z");
+  store.close();
+});
+
+test("touchSalience is a no-op on an unknown key", () => {
+  const store = new SqliteStore(":memory:");
+  assert.equal(store.touchSalience("nope", "2026-01-01T00:00:00.000Z"), undefined);
+  store.close();
+});
+
+test("repeated touchSalience accumulates with diminishing returns", () => {
+  const store = new SqliteStore(":memory:");
+  store.put(buildCell({ kind: "obs", title: "a", body: "b", confidence: 0.7 }, { key: "touch2" }));
+  store.touchSalience("touch2", "2026-01-01T00:00:00.000Z"); // -> 0.6
+  const twice = store.touchSalience("touch2", "2026-01-02T00:00:00.000Z"); // -> 0.68
+  assert.ok(Math.abs(twice!.scores.salienceSeed - 0.68) < 1e-9);
+  store.close();
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,6 +18,7 @@ import type {
 } from "./types.js";
 import { openDb, type Db } from "./db.js";
 import { buildFtsMatchQuery } from "./retrieval.js";
+import { salienceBump } from "./scores.js";
 import { normalizeHyperedgeMembers } from "./hyperedges.js";
 import type { ProgramRun } from "./programs.js";
 import type { StoredEvalRun } from "./evals.js";
@@ -142,6 +143,25 @@ export class SqliteStore implements Store {
     }
 
     this.indexCell(cell);
+  }
+
+  // Retrieval bump: the one place salience accumulates. A genuine single-cell
+  // read (cell show / recall_cell) reinforces attention. Preserves updatedAt so
+  // currency (freshness) is untouched; salience is anchored to lastSalientAt
+  // instead. Feature-detected by callers with "touchSalience" in store, and a
+  // no-op on an unknown key. Not part of the Store interface: a SqliteStore-only
+  // extension, so read-only surfaces (the federated store) never bump.
+  touchSalience(key: string, now: string, gain?: number): Cell | undefined {
+    const cell = this.get(key);
+    if (!cell) return undefined;
+    const seed = salienceBump(cell.scores.salienceSeed, gain);
+    const updated: Cell = {
+      ...cell,
+      scores: { ...cell.scores, salienceSeed: seed, salience: seed },
+      lastSalientAt: now,
+    };
+    this.put(updated);
+    return updated;
   }
 
   get(key: string): Cell | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,11 @@ export interface Cell {
   props: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
+  // The salience anchor: when this cell was last reinforced by a retrieval. The
+  // operator decays salience from this timestamp, distinct from updatedAt (the
+  // currency anchor), so a read reinforces attention without refreshing freshness.
+  // Absent until the cell is first retrieved; decay then falls back to updatedAt.
+  lastSalientAt?: string;
   status: "active" | "superseded" | "annexed";
 }
 


### PR DESCRIPTION
## What

Wires the two score *producers* that the codebase already had consumers for but never fed, so `actorCalibration` and `salience` move from real signal instead of sitting at their neutral seed.

### Actor calibration
- `actors.ts`: derives an actor's `ActorOutcome[]` from the store (a past write is contradicted if it was superseded or carries an incoming active `contradicts` edge, else survived) and `actorCalibrationFactor(store, actorId)` runs the existing `calibration.ts` Brier math over it.
- Wired at the store-aware boundary: CLI `admit`/`write-propose` and MCP `recall_write` derive the factor for the write's actor (keyed on `owner`, default `claude-code`) and pass it as `calibrationFactor`. `admit()` is unchanged, so the store-free library contract and its neutral-default tests are untouched.
- Neutral (1) until the actor has >= 3 resolved outcomes; a proven-miscalibrated actor's new writes deflate at intake.

### Salience
- `salienceDecay`/`salienceBump` in `scores.ts` (tau 30d, floor 0.05, gain 0.2).
- The operator tick leaks salience from a new `lastSalientAt` anchor toward the floor, distinct from the currency anchor (`updatedAt`) so a read reinforces attention without refreshing freshness; pinned cells are exempt like currency.
- `SqliteStore.touchSalience` is the single accumulation point (preserves `updatedAt`); MCP `recall_cell` bumps on agent retrieval. CLI `cell show` stays a pure read so archive export/re-import round-trips remain idempotent.

## Tests
New `actors.test.ts` (outcomes, factor, floor, actor scoping, end-to-end into `admit`) plus salience cases across `scores`/`operator`/`store` tests. Full `release:check` passes: 807 tests, typecheck, build, python tests, acceptance harness, pack dry-run.

## Notes
No schema migration: `lastSalientAt` rides in the cell JSON blob and calibration is computed on read. Actor calibration is compute-on-read per write (a store scan); a standing actor table is a reasonable future optimization but out of scope here.