### PR TITLE
fix(programs): read a program's baseline from the store, not the passed cell

### DIFF
--- a/src/programs.test.ts
+++ b/src/programs.test.ts
@@ -104,6 +104,54 @@ test("watch programs use lastRun as baseline and derive witnesses only after a t
   }
 });
 
+test("a watch program trips even when the caller reuses a stale in-memory program cell across runs (baseline is store-authoritative)", () => {
+  const store = new SqliteStore(":memory:");
+  try {
+    const watched = buildCell(
+      { kind: "obs", title: "Watched", body: "watched", confidence: 0.9, topics: ["gate"] },
+      { key: "aaaaaaaa-9999-9999-9999-999999999999" },
+    );
+    const program = buildCell(
+      {
+        kind: "prg",
+        title: "Stale-object watch",
+        body: "watch gate members",
+        confidence: 0.9,
+        topics: ["gate"],
+        props: {
+          program: {
+            schemaVersion: "recall.program.v1",
+            operation: "watch",
+            target: { keys: [watched.key] },
+            params: { delta: 0.1 },
+          },
+        },
+      },
+      { key: "cccccccc-9999-9999-9999-999999999999" },
+    );
+    store.put(watched);
+    store.put(program);
+
+    // Pass the SAME in-memory `program` object to both runs. Its props.lastRun is
+    // never updated locally (persistProgramRun writes to the store), so before the
+    // fix run 2 read a null baseline and never tripped. Now the baseline is read
+    // from the store, so the drop is detected.
+    const baseline = runProgramCell(store, program, "2026-06-26T12:00:00.000Z");
+    assert.equal(baseline.run.output.tripped, false);
+    assert.equal(baseline.run.output.previous, null);
+
+    store.put({ ...watched, scores: { ...watched.scores, effective: 0.4 } });
+    const tripped = runProgramCell(store, program, "2026-06-26T12:01:00.000Z");
+    assert.equal(tripped.run.output.previous, 0.9);
+    assert.equal(tripped.run.output.tripped, true);
+
+    // runCount is store-authoritative too: two runs, not stuck at 1.
+    assert.equal(store.get(program.key)!.props.runCount, 2);
+  } finally {
+    store.close();
+  }
+});
+
 test("re-tripping a watch program on the same before/after swing derives one cell, not two (deriveAdmit short-circuit)", () => {
   const store = new SqliteStore(":memory:");
   try {

--- a/src/programs.ts
+++ b/src/programs.ts
@@ -125,8 +125,14 @@ export function runProgramCell(
   now: string,
   opts: { derive?: boolean } = {},
 ): { run: ProgramRun; derived?: AdmissionResult } {
-  const program = typeof programKeyOrCell === "string" ? store.get(programKeyOrCell) : programKeyOrCell;
-  if (!program) throw new Error(`unknown program: ${programKeyOrCell}`);
+  const key = typeof programKeyOrCell === "string" ? programKeyOrCell : programKeyOrCell.key;
+  // The store is the source of truth for a program's own state: its props.lastRun
+  // baseline and runCount. Re-read it here so a caller that reuses a stale
+  // in-memory program object across runs still sees its own prior run; otherwise
+  // watch/drift/trend read a null baseline every time and silently never trip.
+  // Falls back to the passed cell only when the program is not yet persisted.
+  const program = store.get(key) ?? (typeof programKeyOrCell === "string" ? undefined : programKeyOrCell);
+  if (!program) throw new Error(`unknown program: ${key}`);
   const spec = programSpecFromCell(program);
   if (!spec) throw new Error(`cell is not a program: ${program.key}`);
 


### PR DESCRIPTION
## The footgun

`runProgramCell` read a program's own persisted state (the `props.lastRun` baseline and `runCount`) off the cell object passed to it. `runStandingPrograms` fetches fresh cells via `store.active()` each tick, and both production callers (CLI `program run`, MCP `recall_program_run`) pass a key or a freshly fetched cell, so this was correct in every real path. But a direct programmatic caller reusing a stale in-memory program object across runs read a null baseline every time, so `watch`/`drift`/`trend` silently never tripped and never derived a witness, with no error.

## The fix

Make the store authoritative for a program's own state: re-read the cell by key at the top of `runProgramCell`, falling back to the passed object only when the program is not yet persisted (a fresh, un-`put` cell). The passed-cell form stays a convenience that is reconciled against the store rather than trusted as a snapshot. This also fixes `runCount`, which was likewise read from the passed object.

## Test

Adds a regression test that runs a `watch` program twice with the same stale in-memory cell object and asserts the second run reads the real baseline, trips, and that `runCount` reaches 2. Full `release:check` green (808 tests, typecheck, build, python, acceptance, pack).