### PR TITLE
fix(store): retrieve non-ASCII content by keeping Unicode letters in query tokenization

### DIFF
--- a/src/semantic.ts
+++ b/src/semantic.ts
@@ -111,9 +111,13 @@ function httpEmbedding(url: string, text: string): EmbeddingRecord | null {
 }
 
 function tokenize(text: string): string[] {
+  // Keep Unicode letters/digits so non-ASCII content contributes real tokens to
+  // the hash:v1 fallback embedding instead of a degenerate vector. ASCII-only
+  // text tokenizes identically to the prior [^a-z0-9_:-] split, so existing
+  // embeddings are unchanged; only non-ASCII-bearing text gains coverage.
   return text
     .toLowerCase()
-    .split(/[^a-z0-9_:-]+/g)
+    .split(/[^\p{L}\p{N}_:-]+/gu)
     .filter((t) => t.length > 1);
 }
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { SqliteStore, contentKey } from "./store.js";
+import { SqliteStore, contentKey, searchTerms } from "./store.js";
 import { buildCell } from "./build.js";
 
 function tempDbDir(): string {
@@ -120,6 +120,33 @@ test("golden: store.search returns same hits before and after buildFtsMatchQuery
   const hitsC = store.search("tripwire sentinel");
   assert.ok(hitsC.some((h) => h.cell.key === "cell-b"), "cell-b must be in results for tripwire sentinel");
 
+  store.close();
+});
+
+test("searchTerms keeps Unicode letters and digits so non-ASCII queries survive", () => {
+  // Cyrillic, accented Latin, and CJK all survive tokenization; an ASCII-only
+  // split used to drop them, leaving the term list empty or truncated.
+  assert.deepEqual(searchTerms("привет мир"), ["привет", "мир"]);
+  assert.deepEqual(searchTerms("café"), ["café"]);
+  assert.ok(searchTerms("东京 tower").includes("东京"));
+  // symbol tokens with the kept _:- class stay intact
+  assert.ok(searchTerms("py-sym:foo_bar").includes("py-sym:foo_bar"));
+  // ASCII-only input tokenizes exactly as before
+  assert.deepEqual(searchTerms("watchdog tripwire"), ["watchdog", "tripwire"]);
+});
+
+test("store.search retrieves non-ASCII content by its own term", () => {
+  const store = new SqliteStore(":memory:");
+  store.put(buildCell({ kind: "obs", title: "заметка привет sentinel", body: "тело привет", confidence: 0.7 }, { key: "cyr" }));
+  store.put(buildCell({ kind: "obs", title: "carte café menu", body: "boisson chaude", confidence: 0.7 }, { key: "acc" }));
+  store.put(buildCell({ kind: "obs", title: "banana orange", body: "fruit salad", confidence: 0.7 }, { key: "ascii" }));
+
+  // Cyrillic term retrieves the Cyrillic cell (previously returned nothing).
+  assert.ok(store.search("привет").some((h) => h.cell.key === "cyr"), "Cyrillic term must retrieve its cell");
+  // Accented Latin retrieves through the diacritic-folded index.
+  assert.ok(store.search("café").some((h) => h.cell.key === "acc"), "accented term must retrieve its cell");
+  // ASCII retrieval is unaffected.
+  assert.ok(store.search("banana").some((h) => h.cell.key === "ascii"), "ASCII term still retrieves its cell");
   store.close();
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -31,9 +31,15 @@ export function contentKey(kind: string, title: string): string {
 }
 
 export function searchTerms(query: string): string[] {
+  // Split on any non-word char while keeping Unicode letters/digits (\p{L}\p{N})
+  // so non-ASCII queries (Cyrillic, Greek, CJK, accented Latin) survive to the
+  // FTS MATCH. The porter unicode61 index already tokenizes this content; an
+  // ASCII-only split here (the prior [^a-z0-9_:-]) silently dropped every
+  // non-ASCII character and made that content unretrievable by its own term.
+  // The _:- class is kept so symbol tokens like py-sym:foo_bar stay intact.
   return query
     .toLowerCase()
-    .split(/[^a-z0-9_:-]+/g)
+    .split(/[^\p{L}\p{N}_:-]+/gu)
     .filter((term) => term.length > 1)
     .slice(0, 8);
 }


### PR DESCRIPTION
## What

`store.search()` could not retrieve non-ASCII content by its own term. `store.searchTerms` and `semantic.tokenize` split the query on `/[^a-z0-9_:-]+/`, which treats every non-ASCII character as a delimiter and drops it:

- Cyrillic / Greek / CJK (e.g. `привет`) tokenized to an empty list, so `store.search` returned no hits at all.
- Accented Latin (`café`) lost its accented letters and missed the diacritic-folded index term.

The `porter unicode61` FTS index tokenizes all of this correctly, and the raw MATCH built from the exact query returns the cell, so content was indexed and matchable at the SQL layer but unreachable through the store's own query path. The compile path (`retrieval.ts` `searchTerms`) was already Unicode-safe; only the store-level and semantic tokenizers were ASCII-only.

## Fix

Both splits become `/[^\p{L}\p{N}_:-]+/gu`, keeping Unicode letters and digits while preserving the `_:-` symbol class. ASCII-only input tokenizes identically, so existing `hash:v1` embeddings and lexical results are byte for byte unchanged; only non-ASCII content gains coverage.

## Tests

Adds `store.test.ts` coverage:
- `searchTerms` keeps Cyrillic, accented Latin, and CJK terms, keeps symbol tokens (`py-sym:foo_bar`), and leaves ASCII tokenization unchanged.
- `store.search` retrieves Cyrillic and accented-Latin cells by their own term, with ASCII retrieval unaffected.

Full suite: 812 pass, 0 fail.

Surfaced by the AMBIENT retrieval-fidelity probe, which mis-scored ranking at 11/20 because its discriminator token carried a Cyrillic character the query path dropped.
