### PR TITLE
Compile through authored Recall graph edges

### DIFF
--- a/integrations/codex/skill/SKILL.md
+++ b/integrations/codex/skill/SKILL.md
@@ -41,6 +41,9 @@ uncertain scope.
 4. Call `recall_write` for lasting outcomes: decisions, verified observations,
    beliefs that need later confirmation, open tasks, objectives, risks,
    references, verification results, hypotheses, and standing procedures.
+   Before a structurally rich write, call `recall_write_template` and use its
+   complete admission-firewall contract; do not reduce a cell to the few fields
+   remembered from ordinary writes.
 5. Read the write response. Report memory as saved only when `accepted` is true
    and an `id` is returned. Address rejection issues instead of claiming success.
 6. Before ending substantial work, audit whether the outcome needs durable

--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -408,6 +408,20 @@ test("compileContext: depends_on + contradicts edges render in relation order an
   store.close();
 });
 
+test("compileContext walks authored edges beyond the lexical entry node", () => {
+  const store = new SqliteStore(":memory:");
+  store.put(buildCell({ kind: "ver", title: "deep graph evidence", body: "e", confidence: 0.8 }, { key: "deep" }));
+  store.put(buildCell({ kind: "obs", title: "mapped intermediate", body: "m", confidence: 0.8, edges: [{ relation: "derived_from", target: "deep" }] }, { key: "middle" }));
+  store.put(buildCell({ kind: "dec", title: "watchdog graph doorway", body: "d", confidence: 0.8, edges: [{ relation: "depends_on", target: "middle" }] }, { key: "door" }));
+
+  const packet = compileContext(store, "watchdog doorway", { limit: 1, graphDepth: 2 });
+  assert.ok(packet.expansionHandles.includes("middle"));
+  assert.ok(packet.expansionHandles.includes("deep"));
+  assert.ok(packet.translatedReferences.some((line) => /graph_path:2/.test(line) && /ver_/.test(line)));
+  assert.ok(packet.compilerState.some((line) => /graph_walk=seeded:1, discovered:2, depth:2/.test(line)));
+  store.close();
+});
+
 test("compileContext: 8 edges on one cell yield 6 translated lines plus an overflow line", () => {
   const store = new SqliteStore(":memory:");
   const edges: { relation: string; target: string }[] = [];

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -32,6 +32,7 @@ export interface ContextCompileOptions {
   includeHealth?: boolean; // default true
   inlineReferenceValues?: boolean; // default false
   includeReferenceParameters?: boolean; // default false
+  graphDepth?: number; // default 2; authored-edge traversal after lexical seeding
 }
 
 export interface ContextPacket {
@@ -91,6 +92,8 @@ export function compileContext(
     now,
     { kindLexicalFactor: TASK_CONTEXT_KIND_FACTOR },
   );
+  const graphDepth = Math.max(0, Math.min(4, opts.graphDepth ?? 2));
+  const walked = walkAuthoredGraph(store, fusedHits.map((hit) => hit.cell), graphDepth, Math.max(limit * 3, 12));
 
   const stats = store.stats();
   const packet: ContextPacket = {
@@ -98,7 +101,8 @@ export function compileContext(
     compilerState: [
       `retrieval=${stats.lexicalBackend}; query="${trimWords(objective, 24)}"; selected_cells=${fusedHits.length}; budget_words=${budget}`,
       `graph=cells:${stats.cells}, active:${stats.activeCells}, edges:${stats.edges}, indexed:${stats.indexedCells}`,
-      "policy=ids-first; use expansion_handles with inspectCell() for exact fields",
+      `graph_walk=seeded:${fusedHits.length}, discovered:${walked.length}, depth:${graphDepth}; authored edges are the compile map`,
+      "policy=ids-first; lexical hits are entry nodes; follow expansion_handles for exact fields",
     ],
     relevantMemory: [],
     activeBeliefs: [],
@@ -138,6 +142,23 @@ export function compileContext(
     if (packet.wordCount >= budget) break;
   }
 
+  // The lexical/fused result is only the doorway. Walk the incident authored
+  // edges from those entry nodes and make every discovered node expandable.
+  // This restores graph continuity without inlining bodies or allowing compile
+  // to become a second answer surface.
+  for (const step of walked) {
+    pushUnique(packet.expansionHandles, step.cell.key);
+    pushUnique(packet.translatedReferences, step.path);
+    pushUnique(packet.cellState, cellStateLine(store, step.cell));
+    surfaceDependencies(packet, store, step.cell);
+    surfaceStandingPrograms(packet, store, step.cell);
+    surfaceTranslatedReferences(packet, store, step.cell, {
+      inlineReferenceValues: opts.inlineReferenceValues === true,
+      includeReferenceParameters: opts.includeReferenceParameters === true,
+    });
+    surfaceLowTrust(packet, step.cell);
+  }
+
   // Health signals run analyzeMemory ONCE per compile (not per hit). It is
   // O(active pool) and acceptable at the current scale.
   if (opts.includeHealth !== false) {
@@ -151,6 +172,46 @@ export function compileContext(
   packet.expansionIndex = buildExpansionIndex(store, packet.expansionHandles);
   trimPacket(packet, budget);
   return packet;
+}
+
+interface GraphWalkStep {
+  cell: Cell;
+  path: string;
+}
+
+const GRAPH_RELATION_ORDER = [
+  "supersedes",
+  "depends_on",
+  "contradicts",
+  "concerns",
+  "supports",
+  "derived_from",
+] as const;
+
+function walkAuthoredGraph(store: Store, seeds: Cell[], maxDepth: number, cap: number): GraphWalkStep[] {
+  if (maxDepth <= 0 || cap <= 0) return [];
+  const seen = new Set(seeds.map((cell) => cell.key));
+  const queue = seeds.map((cell) => ({ cell, depth: 0, trail: cell.handle }));
+  const out: GraphWalkStep[] = [];
+  while (queue.length > 0 && out.length < cap) {
+    const current = queue.shift()!;
+    if (current.depth >= maxDepth) continue;
+    const links = [...store.neighbors(current.cell.key)].sort((a, b) => {
+      const ar = GRAPH_RELATION_ORDER.indexOf(a.edge.relation as (typeof GRAPH_RELATION_ORDER)[number]);
+      const br = GRAPH_RELATION_ORDER.indexOf(b.edge.relation as (typeof GRAPH_RELATION_ORDER)[number]);
+      return (ar < 0 ? 99 : ar) - (br < 0 ? 99 : br) || a.cell.key.localeCompare(b.cell.key);
+    });
+    for (const link of links) {
+      if (link.cell.status !== "active" || seen.has(link.cell.key)) continue;
+      seen.add(link.cell.key);
+      const arrow = link.direction === "out" ? ">" : "<";
+      const trail = `${current.trail} .${arrow}${link.edge.relation} ${link.cell.handle}`;
+      out.push({ cell: link.cell, path: `${trail} [graph_path:${current.depth + 1}]` });
+      queue.push({ cell: link.cell, depth: current.depth + 1, trail });
+      if (out.length >= cap) break;
+    }
+  }
+  return out;
 }
 
 // Categorized, human-scannable view of expansionHandles: the raw key list

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -23,7 +23,7 @@ test("initialize returns protocol version and server info", () => {
   store.close();
 });
 
-test("tools/list returns exactly the nineteen-tool surface", () => {
+test("tools/list returns exactly the twenty-tool surface", () => {
   const store = new SqliteStore(":memory:");
   const res = handleMcpRequest(req("tools/list"), store)?.result as any;
   assert.deepEqual(res.tools.map((t: any) => t.name), [
@@ -31,6 +31,7 @@ test("tools/list returns exactly the nineteen-tool surface", () => {
     "recall_search",
     "recall_compile",
     "recall_cell",
+    "recall_write_template",
     "recall_write",
     "recall_semantic",
     "recall_ref",
@@ -43,7 +44,7 @@ test("tools/list returns exactly the nineteen-tool surface", () => {
     "recall_program_runs",
     "recall_eval_run",
     "recall_subgraph",
-      "recall_deltas",
+    "recall_deltas",
     "recall_health",
     "recall_storage",
   ]);
@@ -97,8 +98,8 @@ test("a notification (no id) yields no response", () => {
   store.close();
 });
 
-test("TOOLS is the nineteen-tool surface", () => {
-  assert.equal(TOOLS.length, 19);
+test("TOOLS is the twenty-tool surface", () => {
+  assert.equal(TOOLS.length, 20);
 });
 
 test("recall_semantic returns JSON hits with key/handle/title/score/backend", () => {
@@ -709,6 +710,20 @@ test("recall_write schema declares the evidence fields", () => {
   assert.deepEqual(props.verification?.enum, ["unverified", "checked", "tested", "external"]);
   assert.equal(props.suggestPrograms?.type, "boolean");
   assert.equal(props.props?.type, "object");
+  store.close();
+});
+
+test("recall_write_template exposes the complete admission firewall contract", () => {
+  const store = new SqliteStore(":memory:");
+  const result = callText(handleMcpRequest(req("tools/call", {
+    name: "recall_write_template",
+    arguments: {},
+  }), store));
+  assert.equal(result.schemaVersion, "recall.write.v5");
+  assert.match(result.template.edges, /supports\|contradicts/);
+  assert.match(result.template.flags, /requiresReview/);
+  assert.match(result.template.props, /standing-program/);
+  assert.match(result.template.hyperedges, /bundle memberships/);
   store.close();
 });
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -24,6 +24,7 @@ import { runProgramCell } from "./programs.js";
 import { runAndRecordEval, runEvalAndDerive } from "./evals.js";
 import { subgraphCells, type SubgraphFilter } from "./subgraph.js";
 import type { AdmissionResult, Store, WriteProposal } from "./types.js";
+import { WRITE_TEMPLATE } from "./template.js";
 import type { SqliteStore } from "./store.js";
 
 type JsonRpcId = string | number;
@@ -53,6 +54,7 @@ export const TOOLS = [
   { name: "recall_search", description: "Lexical search; returns id, kind, title, score.", inputSchema: { type: "object", properties: { query: { type: "string" }, limit: { type: "number" } }, required: ["query"] } },
   { name: "recall_compile", description: "Compile a budgeted context packet for a task.", inputSchema: { type: "object", properties: { task: { type: "string" }, words: { type: "number" }, health: { type: "boolean" }, inlineRefs: { type: "boolean" }, refParams: { type: "boolean" } }, required: ["task"] } },
   { name: "recall_cell", description: "Expand one cell by id, prefix, handle, or address.", inputSchema: { type: "object", properties: { idOrAddress: { type: "string" } }, required: ["idOrAddress"] } },
+  { name: "recall_write_template", description: "Return the complete admission-firewall authoring template. Use it before rich writes to inspect every supported WriteProposal field and constraint.", inputSchema: { type: "object", properties: {} } },
   { name: "recall_write", description: "Admit a durable write through the admission gate. kind: dec (decision made), obs (observation), bel (claim to later confirm or refute), tsk (open action), obj (objective), rsk (risk), ref (source reference), ver (verification result), hyp (hypothesis). Prefer bel, tsk, rsk over flat observations when they fit; contradicts and depends_on edges feed the compile packet's conflicts and dependencies sections. Confidence above 0.7 needs verification, sourceRefs, or a weighted supports edge, else it is attenuated. The response includes guidance (candidate edges to similar cells; standing-program suggestions on by default, suggestPrograms false to opt out).", inputSchema: { type: "object", properties: { kind: { type: "string" }, title: { type: "string" }, body: { type: "string" }, confidence: { type: "number" }, value: { type: "number" }, topics: { type: "array", items: { type: "string" } }, entities: { type: "array", items: { type: "string" } }, edges: { type: "array", items: { type: "object", properties: { relation: { type: "string", enum: ["supports", "contradicts", "supersedes", "derived_from", "depends_on", "concerns"] }, target: { type: "string" }, weight: { type: "number" } }, required: ["relation", "target"], additionalProperties: false } }, sourceRefs: { type: "array", items: { type: "string" } }, verification: { type: "string", enum: ["unverified", "checked", "tested", "external"] }, props: { type: "object" }, programs: { type: "array", items: { type: "string" } }, hyperedges: { type: "array" }, suggestPrograms: { type: "boolean" } }, required: ["kind", "title", "body", "confidence"] } },
   { name: "recall_semantic", description: "Semantic (vector) search; returns key, handle, title, score, backend.", inputSchema: { type: "object", properties: { query: { type: "string" }, limit: { type: "number" }, minScore: { type: "number" } }, required: ["query"] } },
   { name: "recall_ref", description: "Resolve a cell reference (handle#field.path) to the addressed value.", inputSchema: { type: "object", properties: { reference: { type: "string" } }, required: ["reference"] } },
@@ -110,6 +112,8 @@ function callTool(
   switch (name) {
     case "recall_status":
       return JSON.stringify(store.stats());
+    case "recall_write_template":
+      return JSON.stringify({ schemaVersion: "recall.write.v5", template: WRITE_TEMPLATE });
     case "recall_search": {
       const query = String(args.query ?? "");
       const limit = typeof args.limit === "number" ? args.limit : 10;


### PR DESCRIPTION
## Summary
- treat lexical/fused compile results as graph entry nodes
- walk authored incident edges up to two hops by default
- add discovered nodes to expansion handles without exposing bodies
- expose the complete admission-firewall template through recall_write_template
- teach the Codex skill to inspect the full contract for rich writes

## Verification
- 827 TypeScript tests passed
- 23 hook tests passed
- typecheck passed
- build passed
- git diff --check passed