### PR TITLE
ci: make the test suite pass on windows-latest

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Force LF on checkout everywhere. The packaged integration assets
+# (SKILL.md, hooks, prompts) are installed byte-for-byte and compared
+# against expected content; a CRLF checkout on Windows changes the bytes
+# and breaks both the tests and sync idempotence.
+* text=auto eol=lf
+*.png binary
+*.gif binary

--- a/src/claude-sync.test.ts
+++ b/src/claude-sync.test.ts
@@ -57,8 +57,11 @@ test("runClaudeSync apply writes settings.json with recall hooks and disables au
     assert.equal(existsSync(mcpPath(home)), true);
     const mcp = JSON.parse(readFileSync(mcpPath(home), "utf8"));
     assert.deepEqual(mcp.mcpServers.recall, { type: "stdio", command: "recall-mcp", args: [], env: {} });
-    assert.equal(statSync(settingsPath(home)).mode & 0o777, 0o600);
-    assert.equal(statSync(mcpPath(home)).mode & 0o777, 0o600);
+    if (process.platform !== "win32") {
+      // NTFS has no POSIX mode bits; Windows stat reports 0o666 for any writable file.
+      assert.equal(statSync(settingsPath(home)).mode & 0o777, 0o600);
+      assert.equal(statSync(mcpPath(home)).mode & 0o777, 0o600);
+    }
   } finally {
     rmSync(home, { recursive: true, force: true });
   }
@@ -283,7 +286,10 @@ test("runClaudeSync apply installs the recall-session-start.py hook asset and re
     assert.equal(existsSync(hookAssetPath(home)), true);
     assert.ok(result.assetsInstalled.includes(hookAssetPath(home)));
     assert.equal(result.assetsSkipped, undefined);
-    assert.equal(statSync(hookAssetPath(home)).mode & 0o777, 0o700);
+    if (process.platform !== "win32") {
+      // NTFS has no POSIX mode bits; Windows stat reports 0o666 for any writable file.
+      assert.equal(statSync(hookAssetPath(home)).mode & 0o777, 0o700);
+    }
     const installed = readFileSync(hookAssetPath(home), "utf8");
     const source = readFileSync(join(process.cwd(), "integrations", "claude", "hooks", "recall-session-start.py"), "utf8");
     assert.equal(installed, source);

--- a/src/codex-sync.test.ts
+++ b/src/codex-sync.test.ts
@@ -102,12 +102,15 @@ test("runCodexSync apply writes config.toml with the recall MCP block and AGENTS
     assert.deepEqual(Object.keys(hooks.hooks).sort(), ["PostToolUse", "SessionStart", "Stop", "UserPromptSubmit"]);
     assert.match(JSON.stringify(hooks.hooks.PostToolUse), /--tool/);
     assert.doesNotMatch(JSON.stringify(hooks), /UserPromptExpansion|--expansion/);
-    assert.equal(statSync(configPath(home)).mode & 0o777, 0o600);
-    assert.equal(statSync(agentsPath(home)).mode & 0o777, 0o600);
-    assert.equal(statSync(skillPath(home)).mode & 0o777, 0o600);
-    assert.equal(statSync(promptPath(home)).mode & 0o777, 0o600);
-    assert.equal(statSync(hooksPath(home)).mode & 0o777, 0o600);
-    assert.equal(statSync(hookPath(home)).mode & 0o777, 0o700);
+    if (process.platform !== "win32") {
+      // NTFS has no POSIX mode bits; Windows stat reports 0o666 for any writable file.
+      assert.equal(statSync(configPath(home)).mode & 0o777, 0o600);
+      assert.equal(statSync(agentsPath(home)).mode & 0o777, 0o600);
+      assert.equal(statSync(skillPath(home)).mode & 0o777, 0o600);
+      assert.equal(statSync(promptPath(home)).mode & 0o777, 0o600);
+      assert.equal(statSync(hooksPath(home)).mode & 0o777, 0o600);
+      assert.equal(statSync(hookPath(home)).mode & 0o777, 0o700);
+    }
   } finally {
     rmSync(home, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes the five Windows-only test failures from CI run 29150895300 (merge of #42). All Linux and macOS jobs were already green.

Root cause 1: POSIX mode assertions. NTFS has no POSIX permission bits; Node's stat reports 0o666 for any writable file, so asserting 0o600/0o700 after chmod can never pass on Windows (tests 139, 150, 230). The assertions are now gated to non-Windows platforms. The production chmod calls are untouched: they are best-effort hardening and correct on POSIX.

Root cause 2: CRLF checkout. The repo had no .gitattributes, so core.autocrlf on the Windows runners checked the packaged integration assets out with CRLF, and the SKILL.md front-matter regexes (which require bare LF) could not match (tests 162, 239). Added .gitattributes with 'text=auto eol=lf' plus explicit binary rules for images. A 'git add --renormalize' pass shows zero changes, confirming every committed text blob is already LF; the file only pins checkout behavior.

Verification: 827/827 Node tests and 23/23 Python hook tests pass locally on macOS, typecheck clean. Windows cannot be reproduced locally, so this PR's own windows-latest jobs are the proof; the red baseline is the linked failing run.