### PR TITLE
feat: codex write-gate parity and turn-closure receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Agent-integrity write gate trial: Codex now has `recall codex sync --write-gate` parity. The opt-in MCP registration activates the existing admission gate's complete-envelope mode: every authorable primitive must be present and differ from its instructional template, and every durable write must carry at least one honest resolvable edge. Explicit nulls represent genuinely inapplicable optional primitives and are normalized before ordinary v5 validation.
+- Turn closure: prompt markers now carry session, turn, cwd, and start time. A new PostToolUse receipt hook attributes only accepted `recall_write` IDs to the matching turn; rejected, stale, Bash-spoofed, daemon, and ambient writes cannot satisfy the agent's obligation. Stop verifies those IDs in the registered project graph instead of silently checking home, records them in its closure receipt, and accepts the exact auditable no-write footer `[Recall no-write: no durable outcome]` so enforcement never rewards fabricated memory or relationships.
+
 ## 0.12.1 - 2026-07-11
 
 Two score producers that the effective and salience formulas already consumed but nothing fed are now wired, so both scores move from real signal instead of sitting at their neutral seed.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Requires Node.js 22.13 or newer (Recall uses the built-in `node:sqlite`; Node fl
 ```sh
 cd ~/code/my-project
 recall project init                 # this project gets its own graph
-recall claude sync --apply          # Codex: recall codex sync --apply
+recall claude sync --apply          # Codex: recall codex sync --apply [--write-gate]
 ```
 
 That is the whole setup, and the last memory management a human does. From here the agent runs its own memory: hooks prime every prompt from the graph, the agent writes back what it learns through the gate, and the substrate maintains itself between turns. Sync previews its changes by default and backs up any file it modifies.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -618,13 +618,20 @@ it does change is backed up first (a `.bak` copy of prior content).
 hooks installed, whether built-in auto-memory is disabled, and whether the
 `recall` MCP server is registered (`mcpPath`, `mcpInstalled`).
 
-**`recall codex sync [--apply]`** (bare `recall codex` is the same) wires
+**`recall codex sync [--apply] [--write-gate]`** (bare `recall codex` is the same) wires
 Recall into Codex: installs the packaged Recall skill at
 `$CODEX_HOME/skills/recall/SKILL.md`, generates the `/recall` prompt at
 `$CODEX_HOME/prompts/recall.md`, merges MCP server registration into Codex's
 config, merges a Recall block into `AGENTS.md`, and installs the portable
 `SessionStart`, `UserPromptSubmit`, `PostToolUse`, and `Stop` hooks. Same
 dry-run-by-default and backup behavior as `claude sync`.
+
+`--write-gate` adds the turn marker, accepted-write receipt, and Stop closure handlers and sets
+`RECALL_INTEGRITY_GATE=1` on the registered MCP server. Interactive writes then
+use the same admission gate with the complete-template and mandatory-edge
+contract; omitted primitives, untouched template instructions, empty edges,
+and dangling targets reject. A turn with no durable outcome closes through the
+explicit no-write receipt instead of fabricating memory.
 
 **`recall codex status`** reports whether the MCP server is registered, whether
 the `AGENTS.md` Recall block is present, whether the skill and prompt are

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -65,10 +65,11 @@ Every command the tree documents exists on the current CLI; the session hook's r
 
 ### The write gate (opt-in)
 
-`--write-gate` adds a second command to the `UserPromptSubmit` and `Stop` hook entries: `recall-prompt-hook` and `recall-stop-hook`, two small Node binaries bundled with the package. These implement a stricter, fail-closed gate:
+`--write-gate` adds `recall-prompt-hook`, `recall-receipt-hook`, and `recall-stop-hook` to the prompt, PostToolUse, and Stop events. These small Node binaries enforce turn closure around Recall's one admission gate:
 
-- `recall-prompt-hook` stamps the turn's start time to a marker file (per session under `~/.recall/state/stop/`; the `RECALL_STOP_STATE` environment variable overrides the marker path for both hooks).
-- `recall-stop-hook` checks whether any durable cell was created in Recall since that marker. If nothing was written, it holds the turn open and re-injects the full write template JSON: every field must be replaced with a real value, because admission rejects a field whose submitted value still equals its template description (the fill-or-reject rule). If something was written, it releases the turn and runs a background maintenance tick.
+- `recall-prompt-hook` stamps turn, session, working-directory, and start-time data to a marker file (per session under `~/.recall/state/stop/`; `RECALL_STOP_STATE` overrides the path).
+- `recall-receipt-hook` accepts only a successful `recall_write` PostToolUse result and binds its returned cell ID to the matching session and turn. Bash output, rejected writes, stale turns, and ambient/daemon writes cannot forge this receipt.
+- `recall-stop-hook` routes from the turn working directory, verifies the attributed IDs against that project store, and persists a write/no-write closure receipt. With no attributed write it re-injects the complete template. Strict MCP admission rejects omitted primitives, untouched instructions, and an empty or dangling edge list. If no durable outcome honestly exists, the exact footer `[Recall no-write: no durable outcome]` releases the turn without creating noise.
 
 The hold is fail-closed on the marker: a missing turn-start marker holds the turn. A store that fails to open releases the turn instead, since a gate that cannot read the store cannot judge it. Treat the gate as an opt-in enforcement mechanism, not a default: it will interrupt turns that produce no durable memory write. Claude launches matching command hooks concurrently, so neither handler can depend on array order. The portable Python hook and optional Node write gate keep independent state; `--write-gate` adds the stricter Node handlers alongside the Python handlers.
 
@@ -96,6 +97,12 @@ This updates six surfaces under `$CODEX_HOME` (or `~/.codex` when unset):
 - `~/.codex/hooks/recall-session-start.py`: installs the same portable, reviewed hook used by Claude Code.
 - `~/.codex/hooks.json`: registers Codex's supported subset: `SessionStart`, `UserPromptSubmit`, `PostToolUse`, and `Stop`. Codex has no `UserPromptExpansion` event.
 
+Add `--write-gate` to install the Node prompt/receipt/Stop closure set and set
+`RECALL_INTEGRITY_GATE=1` in the MCP environment. This is opt-in. It advertises
+every write primitive as required, accepts explicit `null` only for genuinely
+inapplicable optional primitives, requires a resolvable graph edge, and exposes
+the same no-write receipt described above.
+
 Re-running sync replaces only Recall-owned handlers and managed content. It refreshes the packaged skill and generated prompt, while preserving unrelated hooks and config even when they share a matcher group with an old Recall handler. Existing files that change receive the same `.bak` backup as the MCP and AGENTS files. `recall codex status` reports the MCP table, AGENTS block, skill and prompt presence/currentness, hook asset, and all four hook registrations without changing anything.
 
 Codex requires review for non-managed command hooks. After the first install, or whenever a hook definition changes, open `/hooks`, inspect the Recall handlers, and trust them. Sync never writes Codex's trust store. Codex launches matching hooks concurrently, and its current `PostToolUse` support does not intercept every unified-exec shell call; the Stop gates therefore remain fail-open and single-shot. If `config.toml` already contains inline `[hooks]` tables, sync reports a warning because Codex recommends one hook representation per config layer.
@@ -108,6 +115,7 @@ Flags:
 
 - `--apply`: write the changes.
 - `--db path`: set `RECALL_DB` for the MCP server entry.
+- `--write-gate`: enable verified turn closure and strict interactive admission.
 
 To remove the integration, delete the `[mcp_servers.recall]` table from `config.toml`, the block between the `recall:begin` / `recall:end` markers in `AGENTS.md`, `skills/recall/SKILL.md`, `prompts/recall.md`, the Recall handlers in `hooks.json`, and the installed hook script, or restore changed files from their `.bak` backups.
 

--- a/integrations/codex/skill/SKILL.md
+++ b/integrations/codex/skill/SKILL.md
@@ -113,6 +113,24 @@ Confidence above `0.7` needs grounding through `checked`, `tested`, or
 `external` verification, `sourceRefs`, a positive `supports` edge, or a
 `derived_from` edge; otherwise Recall attenuates it. Never invent grounding.
 
+### Integrity-gate mode
+
+When Codex was installed with `recall codex sync --apply --write-gate`, the
+same admission gate runs in strict envelope mode. Call `recall_write_template`
+and submit every primitive it returns. Replace every instructional default;
+use typed empty collections or `null` only when a primitive is genuinely not
+applicable. Include at least one honest, resolvable edge so the write joins the
+concept graph. Do not invent a cell or relationship merely to close the turn.
+
+Treat the returned accepted cell `id` as the write receipt. The PostToolUse
+receipt hook binds that accepted ID to the current session and turn; a cell
+created by a daemon or other ambient writer does not satisfy your obligation.
+If the turn produced
+no durable decision, evidence, correction, task, risk, or verified outcome, do
+not write noise: end the final response with exactly
+`[Recall no-write: no durable outcome]`. The Stop hook records that explicit
+no-write closure separately from an admitted-write closure.
+
 ## Corrections
 
 Never silently edit or duplicate an obsolete fact. Search for the prior cell,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "recall": "dist/cli.js",
         "recall-mcp": "dist/mcp-cli.js",
         "recall-prompt-hook": "dist/prompt-hook.js",
+        "recall-receipt-hook": "dist/receipt-hook.js",
         "recall-stop-hook": "dist/stop-hook.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "recall": "dist/cli.js",
     "recall-mcp": "dist/mcp-cli.js",
     "recall-stop-hook": "dist/stop-hook.js",
-    "recall-prompt-hook": "dist/prompt-hook.js"
+    "recall-prompt-hook": "dist/prompt-hook.js",
+    "recall-receipt-hook": "dist/receipt-hook.js"
   },
   "exports": {
     ".": {
@@ -76,7 +77,7 @@
     "test:python": "npm run build && python3 -m unittest discover -s python/tests",
     "test:acceptance": "node scripts/release-acceptance.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "build": "rm -rf dist && tsc -p tsconfig.json && chmod +x dist/cli.js dist/mcp-cli.js dist/stop-hook.js dist/prompt-hook.js",
+    "build": "rm -rf dist && tsc -p tsconfig.json && chmod +x dist/cli.js dist/mcp-cli.js dist/stop-hook.js dist/prompt-hook.js dist/receipt-hook.js",
     "prepare": "npm run build",
     "release:check": "npm test && npm run typecheck && npm run build && npm run test:python && npm run test:acceptance && npm pack --dry-run",
     "prepack": "npm run build",

--- a/src/admission.test.ts
+++ b/src/admission.test.ts
@@ -7,6 +7,15 @@ import { WRITE_TEMPLATE } from "./template.js";
 
 const base: WriteProposal = { kind: "dec", title: "t", body: "b", confidence: 0.6 };
 
+function completeProposal(target: string): WriteProposal {
+  const proposal = Object.fromEntries(Object.keys(WRITE_TEMPLATE).map((key) => [key, null])) as Record<string, unknown>;
+  Object.assign(proposal, {
+    kind: "dec", title: "integrity-gated write", body: "verified durable outcome", confidence: 0.8,
+    edges: [{ relation: "depends_on", target }], verification: "tested",
+  });
+  return proposal as unknown as WriteProposal;
+}
+
 test("admit accepts a clean proposal and builds a cell with effective = confidence", () => {
   const r = admit({ ...base }, { key: "c1", now: "2026-06-23T00:00:00Z" });
   assert.equal(r.accepted, true);
@@ -14,6 +23,22 @@ test("admit accepts a clean proposal and builds a cell with effective = confiden
   assert.equal(r.cell?.scores.conf, 0.6);
   assert.equal(r.cell?.scores.effective, 0.6); // calibration 1, no edges
   assert.deepEqual(r.issues, []);
+});
+
+test("integrity mode rejects omitted primitives and empty edges", () => {
+  const r = admit({ ...base, edges: [] }, { integrityGate: true });
+  assert.equal(r.accepted, false);
+  assert.ok(r.issues.some((i) => i.path === "owner" && /missing/.test(i.message)));
+  assert.ok(r.issues.some((i) => i.path === "edges" && /honest/.test(i.message)));
+});
+
+test("integrity mode accepts a complete envelope with null optional values and a resolvable edge", () => {
+  const store = new SqliteStore(":memory:");
+  admit({ ...base }, { key: "anchor", store });
+  const r = admit(completeProposal("anchor"), { key: "strict", store, integrityGate: true });
+  assert.equal(r.accepted, true);
+  assert.equal(r.cell?.edgesOut[0]?.target, "anchor");
+  store.close();
 });
 
 test("admit rejects a schema-invalid proposal and builds no cell", () => {

--- a/src/admission.ts
+++ b/src/admission.ts
@@ -25,12 +25,26 @@ export interface AdmitContext {
   key?: string;
   now?: string;
   store?: Store; // when present, R2 runs dedup, supersede, and real masses
+  /** Opt-in agent-integrity contract for interactive LLM writes. */
+  integrityGate?: boolean;
 }
 
 export function admit(
   proposal: WriteProposal,
   ctx: AdmitContext = {},
 ): AdmissionResult {
+  // In integrity mode, inspect the raw envelope before normalization so an
+  // explicit null is distinguishable from an omitted primitive. Null means
+  // "not applicable" for optional fields and is removed before v5 validation.
+  const filled = templateIssues(proposal, {
+    requireComplete: ctx.integrityGate === true,
+    requireEdge: ctx.integrityGate === true,
+  });
+  if (filled.length > 0) {
+    return { accepted: false, issues: filled, warnings: [], attenuations: [] };
+  }
+  if (ctx.integrityGate) proposal = normalizeExplicitNulls(proposal);
+
   const validation = validateProposal(proposal);
   if (!validation.ok) {
     return { accepted: false, issues: validation.issues, warnings: [], attenuations: [] };
@@ -58,11 +72,6 @@ export function admit(
 
   // Fill-or-reject: any field still equal to its template description was never
   // filled. Reject; the Stop hook holds the turn until the template is complete.
-  const filled = templateIssues(proposal);
-  if (filled.length > 0) {
-    return { accepted: false, issues: filled, warnings: [], attenuations: [] };
-  }
-
   const factor = ctx.calibrationFactor ?? 1;
   if (!Number.isFinite(factor) || factor < 0.5 || factor > 1) {
     return {
@@ -234,4 +243,12 @@ export function admit(
     warnings: [...screenWarnings, ...att.warnings, ...relWarnings],
     attenuations,
   };
+}
+
+function normalizeExplicitNulls(proposal: WriteProposal): WriteProposal {
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(proposal as unknown as Record<string, unknown>)) {
+    if (value !== null) normalized[key] = value;
+  }
+  return normalized as unknown as WriteProposal;
 }

--- a/src/claude-integration.test.ts
+++ b/src/claude-integration.test.ts
@@ -37,16 +37,18 @@ test("recallHookGroups default output has the canonical five-event shape", () =>
   });
 });
 
-test("recallHookGroups writeGate appends the node prompt/stop hooks after the python entries", () => {
+test("recallHookGroups writeGate appends prompt, receipt, and stop handlers", () => {
   const withGate = recallHookGroups(HOOK, {
-    writeGate: { stopHookCommand: "recall-stop-hook", promptHookCommand: "recall-prompt-hook" },
+    writeGate: { stopHookCommand: "recall-stop-hook", promptHookCommand: "recall-prompt-hook", receiptHookCommand: "recall-receipt-hook" },
   });
   const withoutGate = recallHookGroups(HOOK);
 
   // Events unrelated to the optional write gate are untouched.
   assert.deepEqual(withGate.SessionStart, withoutGate.SessionStart);
   assert.deepEqual(withGate.UserPromptExpansion, withoutGate.UserPromptExpansion);
-  assert.deepEqual(withGate.PostToolUse, withoutGate.PostToolUse);
+  const toolHooks = (withGate.PostToolUse as { hooks: unknown[] }).hooks;
+  assert.equal(toolHooks.length, 2);
+  assert.deepEqual(toolHooks[1], { type: "command", command: "recall-receipt-hook" });
 
   const promptHooks = (withGate.UserPromptSubmit as { hooks: unknown[] }).hooks;
   assert.equal(promptHooks.length, 2);
@@ -121,13 +123,14 @@ test("mergeClaudeSettings preserves unrelated sibling handlers in a mixed matche
 });
 
 test("mergeClaudeSettings toggles optional node write gates without leftovers or duplicates", () => {
-  const gate = { stopHookCommand: "recall-stop-hook", promptHookCommand: "recall-prompt-hook" };
+  const gate = { stopHookCommand: "recall-stop-hook", promptHookCommand: "recall-prompt-hook", receiptHookCommand: "recall-receipt-hook" };
   const enabled = mergeClaudeSettings({}, { hookCommandPath: HOOK, writeGate: gate });
   const disabled = mergeClaudeSettings(enabled.next, { hookCommandPath: HOOK });
-  assert.doesNotMatch(JSON.stringify(disabled.next.hooks), /recall-(?:prompt|stop)-hook/);
+  assert.doesNotMatch(JSON.stringify(disabled.next.hooks), /recall-(?:prompt|stop|receipt)-hook/);
   const reenabled = mergeClaudeSettings(disabled.next, { hookCommandPath: HOOK, writeGate: gate });
   assert.equal((JSON.stringify(reenabled.next.hooks).match(/recall-prompt-hook/g) ?? []).length, 1);
   assert.equal((JSON.stringify(reenabled.next.hooks).match(/recall-stop-hook/g) ?? []).length, 1);
+  assert.equal((JSON.stringify(reenabled.next.hooks).match(/recall-receipt-hook/g) ?? []).length, 1);
 });
 
 test("mergeClaudeSettings can remove the auto-memory disable env", () => {

--- a/src/claude-integration.ts
+++ b/src/claude-integration.ts
@@ -21,7 +21,7 @@ const CLAUDE_HOOK_EVENTS = [
 ] as const;
 
 export interface RecallHookGroupsOpts {
-  writeGate?: { stopHookCommand: string; promptHookCommand: string };
+  writeGate?: { stopHookCommand: string; promptHookCommand: string; receiptHookCommand: string };
 }
 
 export function recallHookGroups(hookCommandPath: string, opts?: RecallHookGroupsOpts): ClaudeHookGroups {
@@ -33,9 +33,11 @@ export function recallHookGroups(hookCommandPath: string, opts?: RecallHookGroup
   // optional Node write-gate hooks below. Every Python mode is fail-open.
   const promptHooks: unknown[] = [{ type: "command", command: `python3 ${quoted} --prompt`, timeout: 10 }];
   const stopHooks: unknown[] = [{ type: "command", command: `python3 ${quoted} --stop`, timeout: 10 }];
+  const toolHooks: unknown[] = [{ type: "command", command: `python3 ${quoted} --tool`, timeout: 10 }];
   if (writeGate) {
     promptHooks.push({ type: "command", command: writeGate.promptHookCommand });
     stopHooks.push({ type: "command", command: writeGate.stopHookCommand });
+    toolHooks.push({ type: "command", command: writeGate.receiptHookCommand });
   }
 
   return {
@@ -50,7 +52,7 @@ export function recallHookGroups(hookCommandPath: string, opts?: RecallHookGroup
     },
     PostToolUse: {
       matcher: "Bash|mcp__recall__.*",
-      hooks: [{ type: "command", command: `python3 ${quoted} --tool`, timeout: 10 }],
+      hooks: toolHooks,
     },
     Stop: {
       hooks: stopHooks,
@@ -118,5 +120,5 @@ function isRecallOwnedHandler(handler: unknown): boolean {
   const command = (handler as { command?: unknown })?.command;
   if (typeof command !== "string") return false;
   return command.includes(HOOK_MARKER)
-    || /(^|\s)recall-(?:prompt|stop)-hook(?:\s|$)/.test(command);
+    || /(^|\s)recall-(?:prompt|stop|receipt)-hook(?:\s|$)/.test(command);
 }

--- a/src/claude-sync.ts
+++ b/src/claude-sync.ts
@@ -121,7 +121,11 @@ export function runClaudeSync(opts: ClaudeSyncOptions = {}): ClaudeSyncResult {
     // The node hooks resolve by bin name (not an absolute path) so PATH
     // resolution matches how npm installs expose them, same as mcpCommand
     // above defaulting to the "recall-mcp" bin name rather than a path.
-    writeGate: opts.writeGate ? { promptHookCommand: "recall-prompt-hook", stopHookCommand: "recall-stop-hook" } : undefined,
+    writeGate: opts.writeGate ? {
+      promptHookCommand: "recall-prompt-hook",
+      stopHookCommand: "recall-stop-hook",
+      receiptHookCommand: "recall-receipt-hook",
+    } : undefined,
   });
   if (apply && settingsMerge.changed.length > 0) {
     const backup = backupIfExists(settingsFile);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -203,7 +203,12 @@ export function runCli(argv: string[], options: RunCliOptions = {}): number {
         // history (buildCell keys producedBy on owner, default "claude-code")
         // and feed it into R1. Neutral (1) until the actor has >= 3 outcomes.
         const calibrationFactor = actorCalibrationFactor(store, proposal.owner ?? "claude-code");
-        const result = admit(proposal, { store, now: options.now, calibrationFactor });
+        const result = admit(proposal, {
+          store,
+          now: options.now,
+          calibrationFactor,
+          integrityGate: args.writeGate,
+        });
         if (result.accepted && result.cell && !args.noGuidance) {
           const suggest = args.noSuggestPrograms
             ? false
@@ -718,6 +723,7 @@ export function runCli(argv: string[], options: RunCliOptions = {}): number {
           codexHome: env.CODEX_HOME,
           apply: args.apply,
           recallDb: args.db,
+          writeGate: args.writeGate,
         }),
       );
       return 0;
@@ -1091,7 +1097,7 @@ Commands:
   recall import local [--global-db path] [--project slug] [--topics a,b] [--limit N] [--no-hyperedges] [--apply] [--db path]
   recall claude sync [--apply] [--keep-automemory] [--write-gate] [--root path] [--db path]  # five lifecycle events
   recall claude status
-  recall codex sync [--apply] [--db path]  # skill + /recall + MCP + AGENTS.md + native hooks; respects CODEX_HOME
+  recall codex sync [--apply] [--write-gate] [--db path]  # skill + /recall + MCP + AGENTS.md + native hooks; respects CODEX_HOME
   recall codex status
   recall reindex [--missing-only] [--db path] [--project slug]
   recall maintain [--all-graphs] [--db path] [--project slug]

--- a/src/codex-integration.test.ts
+++ b/src/codex-integration.test.ts
@@ -37,6 +37,17 @@ test("recallCodexHookGroups installs only Codex-supported portable events", () =
   assert.match(JSON.stringify(groups.PostToolUse), /--tool/);
 });
 
+test("Codex write-gate mode installs one owned prompt/receipt/stop set", () => {
+  const groups = recallCodexHookGroups("/tmp/recall.py", {
+    writeGate: { promptHookCommand: "recall-prompt-hook", stopHookCommand: "recall-stop-hook", receiptHookCommand: "recall-receipt-hook" },
+  });
+  assert.match(JSON.stringify(groups.UserPromptSubmit), /recall-prompt-hook/);
+  assert.match(JSON.stringify(groups.Stop), /recall-stop-hook/);
+  assert.match(JSON.stringify(groups.PostToolUse), /recall-receipt-hook/);
+  const merged = mergeCodexHooks({ hooks: { Stop: [{ hooks: [{ type: "command", command: "recall-stop-hook" }] }] } }, "/tmp/recall.py");
+  assert.equal((JSON.stringify(merged.next).match(/recall-stop-hook/g) ?? []).length, 0);
+});
+
 test("mergeCodexHooks is idempotent and preserves mixed sibling handlers", () => {
   const hook = "/home/user/.codex/hooks/recall-session-start.py";
   const existing = {
@@ -80,6 +91,12 @@ test("recallMcpToml includes optional RECALL_DB env", () => {
   assert.match(toml, /command = "recall-mcp"/);
   assert.match(toml, /\[mcp_servers\.recall\.env\]/);
   assert.match(toml, /RECALL_DB = "\/tmp\/project\.sqlite3"/);
+});
+
+test("recallMcpToml enables strict admission only for write-gate installs", () => {
+  const toml = recallMcpToml("recall-mcp", undefined, true);
+  assert.match(toml, /RECALL_INTEGRITY_GATE = "1"/);
+  assert.doesNotMatch(toml, /RECALL_DB/);
 });
 
 test("upsertCodexMcpServer preserves other TOML and is idempotent", () => {

--- a/src/codex-integration.ts
+++ b/src/codex-integration.ts
@@ -17,8 +17,23 @@ export function mergeAgentsMd(existing: string | undefined | null): { next: stri
 export { recallSlashPrompt };
 
 /** Native Codex subset of the portable Recall lifecycle hook. */
-export function recallCodexHookGroups(hookCommandPath: string): Record<string, unknown> {
+export interface CodexHookGroupsOptions {
+  writeGate?: { stopHookCommand: string; promptHookCommand: string; receiptHookCommand: string };
+}
+
+export function recallCodexHookGroups(
+  hookCommandPath: string,
+  opts: CodexHookGroupsOptions = {},
+): Record<string, unknown> {
   const quoted = JSON.stringify(hookCommandPath);
+  const promptHooks: unknown[] = [{ type: "command", command: `python3 ${quoted} --prompt`, timeout: 10 }];
+  const stopHooks: unknown[] = [{ type: "command", command: `python3 ${quoted} --stop`, timeout: 10 }];
+  const toolHooks: unknown[] = [{ type: "command", command: `python3 ${quoted} --tool`, timeout: 10 }];
+  if (opts.writeGate) {
+    promptHooks.push({ type: "command", command: opts.writeGate.promptHookCommand });
+    stopHooks.push({ type: "command", command: opts.writeGate.stopHookCommand });
+    toolHooks.push({ type: "command", command: opts.writeGate.receiptHookCommand });
+  }
   return {
     SessionStart: {
       hooks: [{
@@ -29,14 +44,14 @@ export function recallCodexHookGroups(hookCommandPath: string): Record<string, u
       }],
     },
     UserPromptSubmit: {
-      hooks: [{ type: "command", command: `python3 ${quoted} --prompt`, timeout: 10 }],
+      hooks: promptHooks,
     },
     PostToolUse: {
       matcher: "Bash|mcp__recall__.*",
-      hooks: [{ type: "command", command: `python3 ${quoted} --tool`, timeout: 10 }],
+      hooks: toolHooks,
     },
     Stop: {
-      hooks: [{ type: "command", command: `python3 ${quoted} --stop`, timeout: 10 }],
+      hooks: stopHooks,
     },
   };
 }
@@ -45,11 +60,12 @@ export function recallCodexHookGroups(hookCommandPath: string): Record<string, u
 export function mergeCodexHooks(
   existing: Record<string, unknown> | undefined | null,
   hookCommandPath: string,
+  opts: CodexHookGroupsOptions = {},
 ): { next: Record<string, unknown>; changed: boolean } {
   const prior = existing ?? {};
   const next: Record<string, unknown> = { ...prior };
   const hooks: Record<string, unknown> = { ...((next.hooks as Record<string, unknown>) ?? {}) };
-  const desired = recallCodexHookGroups(hookCommandPath);
+  const desired = recallCodexHookGroups(hookCommandPath, opts);
 
   for (const event of CODEX_HOOK_EVENTS) {
     const previous = Array.isArray(hooks[event]) ? hooks[event] as unknown[] : [];
@@ -70,22 +86,25 @@ function stripRecallHandlers(group: unknown): unknown | null {
   if (!Array.isArray(handlers)) return group;
   const remaining = handlers.filter((handler) => {
     const command = (handler as { command?: unknown })?.command;
-    return typeof command !== "string" || !command.includes(HOOK_MARKER);
+    return typeof command !== "string" || !(command.includes(HOOK_MARKER)
+      || /(^|\s)recall-(?:prompt|stop|receipt)-hook(?:\s|$)/.test(command));
   });
   return remaining.length > 0 ? { ...(group as Record<string, unknown>), hooks: remaining } : null;
 }
 
-export function recallMcpToml(mcpCommand: string, recallDb?: string): string {
+export function recallMcpToml(mcpCommand: string, recallDb?: string, integrityGate = false): string {
   let text = `[mcp_servers.${MCP_NAME}]\ncommand = ${JSON.stringify(mcpCommand)}\n`;
-  if (recallDb) {
-    text += `\n[mcp_servers.${MCP_NAME}.env]\nRECALL_DB = ${JSON.stringify(recallDb)}\n`;
+  if (recallDb || integrityGate) {
+    text += `\n[mcp_servers.${MCP_NAME}.env]\n`;
+    if (recallDb) text += `RECALL_DB = ${JSON.stringify(recallDb)}\n`;
+    if (integrityGate) text += `RECALL_INTEGRITY_GATE = "1"\n`;
   }
   return text;
 }
 
 export function upsertCodexMcpServer(
   tomlText: string | undefined | null,
-  opts: { mcpCommand: string; recallDb?: string },
+  opts: { mcpCommand: string; recallDb?: string; integrityGate?: boolean },
 ): { next: string; changed: boolean } {
   const prior = tomlText ?? "";
   const lines = prior.split("\n");
@@ -114,7 +133,7 @@ export function upsertCodexMcpServer(
   }
 
   const body = kept.join("\n").replace(/\s+$/, "");
-  const block = recallMcpToml(opts.mcpCommand, opts.recallDb);
+  const block = recallMcpToml(opts.mcpCommand, opts.recallDb, opts.integrityGate);
   const next = body ? `${body}\n\n${block}` : block;
   return { next, changed: next !== prior };
 }

--- a/src/codex-sync.test.ts
+++ b/src/codex-sync.test.ts
@@ -200,6 +200,27 @@ test("runCodexSync honors mcpCommand and recallDb options", () => {
   }
 });
 
+test("runCodexSync writeGate wires strict MCP admission and the owned closure set", () => {
+  const home = tempHome();
+  try {
+    runCodexSync({ home, apply: true, writeGate: true });
+    assert.match(readFileSync(configPath(home), "utf8"), /RECALL_INTEGRITY_GATE = "1"/);
+    const hooks = readFileSync(hooksPath(home), "utf8");
+    assert.equal((hooks.match(/recall-prompt-hook/g) ?? []).length, 1);
+    assert.equal((hooks.match(/recall-stop-hook/g) ?? []).length, 1);
+    assert.equal((hooks.match(/recall-receipt-hook/g) ?? []).length, 1);
+    const status = codexSyncStatus({ home });
+    assert.equal(status.hooksInstalled, true);
+    assert.equal(status.writeGateInstalled, true);
+
+    runCodexSync({ home, apply: true, writeGate: false });
+    assert.doesNotMatch(readFileSync(configPath(home), "utf8"), /RECALL_INTEGRITY_GATE/);
+    assert.doesNotMatch(readFileSync(hooksPath(home), "utf8"), /recall-(?:prompt|stop|receipt)-hook/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test("codexSyncStatus reports false for missing files and flips to installed after apply", () => {
   const home = tempHome();
   try {

--- a/src/codex-sync.ts
+++ b/src/codex-sync.ts
@@ -23,6 +23,8 @@ export interface CodexSyncOptions {
   recallDb?: string;
   apply?: boolean;
   installHook?: boolean;
+  /** Install the opt-in turn closure gate and strict MCP admission contract. */
+  writeGate?: boolean;
 }
 
 export interface CodexSyncResult {
@@ -64,6 +66,7 @@ export function codexSyncStatus(
   hooksPath: string;
   hookPath: string;
   hooksInstalled: boolean;
+  writeGateInstalled: boolean;
   inlineHooksConflict: boolean;
 } {
   const codexHome = resolveCodexHome(opts);
@@ -91,7 +94,17 @@ export function codexSyncStatus(
   const hooksFile = join(codexHome, "hooks.json");
   const hookPath = join(codexHome, "hooks", "recall-session-start.py");
   const hookConfig = readJsonSafe(hooksFile);
-  const hooksInstalled = hookConfig !== null && !mergeCodexHooks(hookConfig, hookPath).changed;
+  const hookText = JSON.stringify(hookConfig ?? {});
+  const writeGateInstalled = hookText.includes("recall-prompt-hook")
+    && hookText.includes("recall-stop-hook")
+    && hookText.includes("recall-receipt-hook");
+  const hooksInstalled = hookConfig !== null && !mergeCodexHooks(hookConfig, hookPath, writeGateInstalled ? {
+    writeGate: {
+      promptHookCommand: "recall-prompt-hook",
+      stopHookCommand: "recall-stop-hook",
+      receiptHookCommand: "recall-receipt-hook",
+    },
+  } : {}).changed;
 
   return {
     codexHome,
@@ -108,6 +121,7 @@ export function codexSyncStatus(
     hooksPath: hooksFile,
     hookPath,
     hooksInstalled: hooksInstalled && existsSync(hookPath),
+    writeGateInstalled,
     inlineHooksConflict: hasInlineCodexHooks(configText),
   };
 }
@@ -121,7 +135,11 @@ export function runCodexSync(opts: CodexSyncOptions = {}): CodexSyncResult {
 
   const configFile = join(codexHome, "config.toml");
   const existingConfig = readTextSafe(configFile);
-  const configMerge = upsertCodexMcpServer(existingConfig, { mcpCommand, recallDb: opts.recallDb });
+  const configMerge = upsertCodexMcpServer(existingConfig, {
+    mcpCommand,
+    recallDb: opts.recallDb,
+    integrityGate: opts.writeGate,
+  });
   if (apply && configMerge.changed) {
     const backup = backupIfExists(configFile);
     if (backup) backups.push(backup);
@@ -183,7 +201,13 @@ export function runCodexSync(opts: CodexSyncOptions = {}): CodexSyncResult {
   const hookIsAvailable = !installHook || hookSource !== null || existsSync(hookPath);
   const existingHooks = readJsonSafe(hooksFile) ?? {};
   const hooksMerge = hookIsAvailable
-    ? mergeCodexHooks(existingHooks, hookCommandPath)
+    ? mergeCodexHooks(existingHooks, hookCommandPath, opts.writeGate ? {
+      writeGate: {
+        promptHookCommand: "recall-prompt-hook",
+        stopHookCommand: "recall-stop-hook",
+        receiptHookCommand: "recall-receipt-hook",
+      },
+    } : {})
     : { next: existingHooks, changed: false };
   if (apply && hooksMerge.changed) {
     const backup = backupIfExists(hooksFile);

--- a/src/mcp-cli.ts
+++ b/src/mcp-cli.ts
@@ -65,7 +65,10 @@ rl.on("line", (line) => {
   } catch {
     return; // ignore non-JSON lines
   }
-  const response = handleMcpRequest(request, store, { project: route.project });
+  const response = handleMcpRequest(request, store, {
+    project: route.project,
+    integrityGate: env.RECALL_INTEGRITY_GATE === "1",
+  });
   if (response) stdout.write(JSON.stringify(response) + "\n");
 });
 

--- a/src/mcp-server.test.ts
+++ b/src/mcp-server.test.ts
@@ -51,6 +51,14 @@ test("tools/list returns exactly the twenty-tool surface", () => {
   store.close();
 });
 
+test("integrity mode advertises every write primitive as required", () => {
+  const store = new SqliteStore(":memory:");
+  const res = handleMcpRequest(req("tools/list"), store, { integrityGate: true })?.result as any;
+  const write = res.tools.find((tool: any) => tool.name === "recall_write");
+  assert.deepEqual(new Set(write.inputSchema.required), new Set(Object.keys(WRITE_TEMPLATE)));
+  store.close();
+});
+
 test("recall_status returns store stats", () => {
   const store = new SqliteStore(":memory:");
   const stats = callText(handleMcpRequest(req("tools/call", { name: "recall_status", arguments: {} }), store));

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -43,11 +43,36 @@ export interface JsonRpcResponse {
 
 export interface McpRequestContext {
   project?: string;
+  integrityGate?: boolean;
 }
 
 const SERVER_NAME = "recall";
 const SERVER_VERSION = "0.12.1";
 const PROTOCOL_VERSION = "2024-11-05";
+
+const nullable = (schema: Record<string, unknown>) => ({ anyOf: [schema, { type: "null" }] });
+const stringArray = { type: "array", items: { type: "string" } };
+const WRITE_TOOL_PROPERTIES = {
+  kind: { type: "string" }, title: { type: "string" }, body: { type: "string" }, confidence: { type: "number" },
+  owner: { type: "string" }, summary: { type: "string" },
+  topics: stringArray, entities: stringArray, lifecycle: stringArray,
+  quality: stringArray, subject: stringArray,
+  edges: { type: "array", items: { type: "object", properties: {
+    relation: { type: "string", enum: ["supports", "contradicts", "supersedes", "derived_from", "depends_on", "concerns"] },
+    target: { type: "string" }, weight: { type: "number" },
+  }, required: ["relation", "target"], additionalProperties: false } },
+  sourceRefs: stringArray, uncertainty: { type: "number" }, concern: { type: "number" },
+  operation: { type: "string", enum: ["create", "update", "supersede", "link", "annex"] },
+  origin: { type: "string", enum: ["human", "llm", "daemon", "connector", "program", "external"] },
+  verification: { type: "string", enum: ["unverified", "checked", "tested", "external"] },
+  sensitivity: { type: "string", enum: ["public", "private", "secret"] },
+  stability: { type: "string", enum: ["ephemeral", "volatile", "stable"] },
+  expiresAt: nullable({ type: "string" }), reverifyAfter: nullable({ type: "string" }),
+  flags: { type: "object" }, props: { type: "object" }, value: nullable({ type: "number" }),
+  programs: stringArray, hyperedges: { type: "array" },
+  project: { type: "string" }, tenant: { type: "string" },
+  suggestPrograms: { type: "boolean" },
+} as const;
 
 export const TOOLS = [
   { name: "recall_status", description: "Graph counts and lexical backend.", inputSchema: { type: "object", properties: {} } },
@@ -55,7 +80,7 @@ export const TOOLS = [
   { name: "recall_compile", description: "Compile a budgeted context packet for a task.", inputSchema: { type: "object", properties: { task: { type: "string" }, words: { type: "number" }, health: { type: "boolean" }, inlineRefs: { type: "boolean" }, refParams: { type: "boolean" } }, required: ["task"] } },
   { name: "recall_cell", description: "Expand one cell by id, prefix, handle, or address.", inputSchema: { type: "object", properties: { idOrAddress: { type: "string" } }, required: ["idOrAddress"] } },
   { name: "recall_write_template", description: "Return the complete admission-firewall authoring template. Use it before rich writes to inspect every supported WriteProposal field and constraint.", inputSchema: { type: "object", properties: {} } },
-  { name: "recall_write", description: "Admit a durable write through the admission gate. kind: dec (decision made), obs (observation), bel (claim to later confirm or refute), tsk (open action), obj (objective), rsk (risk), ref (source reference), ver (verification result), hyp (hypothesis). Prefer bel, tsk, rsk over flat observations when they fit; contradicts and depends_on edges feed the compile packet's conflicts and dependencies sections. Confidence above 0.7 needs verification, sourceRefs, or a weighted supports edge, else it is attenuated. The response includes guidance (candidate edges to similar cells; standing-program suggestions on by default, suggestPrograms false to opt out).", inputSchema: { type: "object", properties: { kind: { type: "string" }, title: { type: "string" }, body: { type: "string" }, confidence: { type: "number" }, value: { type: "number" }, topics: { type: "array", items: { type: "string" } }, entities: { type: "array", items: { type: "string" } }, edges: { type: "array", items: { type: "object", properties: { relation: { type: "string", enum: ["supports", "contradicts", "supersedes", "derived_from", "depends_on", "concerns"] }, target: { type: "string" }, weight: { type: "number" } }, required: ["relation", "target"], additionalProperties: false } }, sourceRefs: { type: "array", items: { type: "string" } }, verification: { type: "string", enum: ["unverified", "checked", "tested", "external"] }, props: { type: "object" }, programs: { type: "array", items: { type: "string" } }, hyperedges: { type: "array" }, suggestPrograms: { type: "boolean" } }, required: ["kind", "title", "body", "confidence"] } },
+  { name: "recall_write", description: "Admit a durable write through the one admission gate. In integrity mode every authorable primitive is required (use null only when genuinely not applicable), and edges must contain at least one honest resolvable connection. Never fabricate a write or edge; use the explicit no-write turn receipt when no durable outcome exists.", inputSchema: { type: "object", properties: WRITE_TOOL_PROPERTIES, required: ["kind", "title", "body", "confidence"] } },
   { name: "recall_semantic", description: "Semantic (vector) search; returns key, handle, title, score, backend.", inputSchema: { type: "object", properties: { query: { type: "string" }, limit: { type: "number" }, minScore: { type: "number" } }, required: ["query"] } },
   { name: "recall_ref", description: "Resolve a cell reference (handle#field.path) to the addressed value.", inputSchema: { type: "object", properties: { reference: { type: "string" } }, required: ["reference"] } },
   { name: "recall_page", description: "Return a curated kind-filtered page view (reflections, objectives, workbench, witnesses, handoffs, team-metrics, agent-profile, user-profile, index).", inputSchema: { type: "object", properties: { name: { type: "string" }, project: { type: "string" }, topics: { type: "array", items: { type: "string" } }, since: { type: "string" }, limit: { type: "number" } }, required: ["name"] } },
@@ -89,7 +114,7 @@ export function handleMcpRequest(
           capabilities: { tools: {} },
         });
       case "tools/list":
-        return ok(id, { tools: TOOLS });
+        return ok(id, { tools: toolsForContext(context) });
       case "tools/call": {
         const name = stringParam(request.params, "name");
         const args = recordParam(request.params, "arguments");
@@ -159,7 +184,7 @@ function callTool(
       // Derive the actor's standing calibration factor from this store's history
       // before R1 folds it into effective. Neutral until >= 3 resolved outcomes.
       const calibrationFactor = actorCalibrationFactor(store, proposal.owner ?? "claude-code");
-      const r = admit(proposal, { store, calibrationFactor });
+      const r = admit(proposal, { store, calibrationFactor, integrityGate: context.integrityGate });
       const suggest = args.suggestPrograms === false ? false : args.suggestPrograms === true ? true : process.env.RECALL_SUGGEST_PROGRAMS !== "0";
       const guidance = r.accepted && r.cell ? buildWriteGuidance(store, r.cell, r, { suggestPrograms: suggest }) : undefined;
       return JSON.stringify({
@@ -354,24 +379,24 @@ function callTool(
 }
 
 function toProposal(args: Record<string, unknown>, project?: string): WriteProposal {
-  return {
-    kind: String(args.kind ?? ""),
-    title: String(args.title ?? ""),
-    body: typeof args.body === "string" ? args.body : "",
-    confidence: typeof args.confidence === "number" ? args.confidence : Number.NaN,
-    topics: Array.isArray(args.topics) ? (args.topics as string[]) : undefined,
-    entities: Array.isArray(args.entities) ? (args.entities as string[]) : undefined,
-    edges: Array.isArray(args.edges) ? (args.edges as WriteProposal["edges"]) : undefined,
-    sourceRefs: Array.isArray(args.sourceRefs) ? (args.sourceRefs as string[]) : undefined,
-    verification: typeof args.verification === "string" ? (args.verification as WriteProposal["verification"]) : undefined,
-    // Passed through unvalidated: schema rejects a present non-object props,
-    // so a malformed value surfaces as a fill-or-reject issue, not a drop.
-    props: args.props === undefined ? undefined : (args.props as WriteProposal["props"]),
-    value: typeof args.value === "number" ? args.value : undefined,
-    programs: Array.isArray(args.programs) ? (args.programs as string[]) : undefined,
-    hyperedges: Array.isArray(args.hyperedges) ? (args.hyperedges as WriteProposal["hyperedges"]) : undefined,
-    project,
-  };
+  const proposal: Record<string, unknown> = {};
+  for (const field of Object.keys(WRITE_TEMPLATE)) {
+    if (Object.prototype.hasOwnProperty.call(args, field)) proposal[field] = args[field];
+  }
+  if (!("kind" in proposal)) proposal.kind = "";
+  if (!("title" in proposal)) proposal.title = "";
+  if (!("body" in proposal)) proposal.body = "";
+  if (!("confidence" in proposal)) proposal.confidence = Number.NaN;
+  if (project !== undefined) proposal.project = project;
+  return proposal as unknown as WriteProposal;
+}
+
+function toolsForContext(context: McpRequestContext): readonly unknown[] {
+  if (!context.integrityGate) return TOOLS;
+  const required = Object.keys(WRITE_TEMPLATE);
+  return TOOLS.map((tool) => tool.name === "recall_write"
+    ? { ...tool, inputSchema: { ...tool.inputSchema, required } }
+    : tool);
 }
 
 function ok(id: JsonRpcId, result: unknown): JsonRpcResponse {

--- a/src/prompt-hook.ts
+++ b/src/prompt-hook.ts
@@ -25,8 +25,13 @@ function main(): void {
     raw = "";
   }
   let sessionId: string | undefined;
+  let turnId: string | undefined;
+  let cwd: string | undefined;
   try {
-    sessionId = (JSON.parse(raw) as { session_id?: string }).session_id;
+    const input = JSON.parse(raw) as { session_id?: string; turn_id?: string; cwd?: string };
+    sessionId = input.session_id;
+    turnId = input.turn_id;
+    cwd = input.cwd;
   } catch {
     // malformed stdin
   }
@@ -34,7 +39,13 @@ function main(): void {
   if (path) {
     try {
       mkdirSync(dirname(path), { recursive: true });
-      writeFileSync(path, JSON.stringify({ turnStart: new Date().toISOString() }));
+      writeFileSync(path, JSON.stringify({
+        turnStart: new Date().toISOString(),
+        sessionId,
+        turnId,
+        cwd,
+        admittedIds: [],
+      }));
     } catch {
       // best effort; if we cannot stamp, the Stop gate fails closed (holds)
     }

--- a/src/receipt-hook.test.ts
+++ b/src/receipt-hook.test.ts
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function runReceipt(statePath: string, input: Record<string, unknown>): void {
+  const result = spawnSync(
+    process.execPath,
+    ["--disable-warning=ExperimentalWarning", "--import", "tsx", join(here, "receipt-hook.ts")],
+    { input: JSON.stringify(input), encoding: "utf8", env: { ...process.env, RECALL_STOP_STATE: statePath } },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {});
+}
+
+test("receipt hook attributes only an accepted recall_write to the matching turn", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "recall-receipt-hook-"));
+  const state = join(tmp, "state.json");
+  try {
+    writeFileSync(state, JSON.stringify({ sessionId: "s1", turnId: "t1", turnStart: "2026-07-12T00:00:00Z", admittedIds: [] }));
+    runReceipt(state, {
+      session_id: "s1", turn_id: "t1", tool_name: "mcp__recall__recall_write",
+      tool_response: { content: [{ type: "text", text: JSON.stringify({ accepted: true, id: "cell-1" }) }] },
+    });
+    assert.deepEqual(JSON.parse(readFileSync(state, "utf8")).admittedIds, ["cell-1"]);
+
+    runReceipt(state, {
+      session_id: "s1", turn_id: "t1", tool_name: "Bash",
+      tool_response: { accepted: true, id: "spoofed" },
+    });
+    runReceipt(state, {
+      session_id: "s1", turn_id: "wrong", tool_name: "mcp__recall__recall_write",
+      tool_response: { accepted: true, id: "wrong-turn" },
+    });
+    runReceipt(state, {
+      session_id: "s1", turn_id: "t1", tool_name: "mcp__recall__recall_write",
+      tool_response: { accepted: false, id: "rejected" },
+    });
+    assert.deepEqual(JSON.parse(readFileSync(state, "utf8")).admittedIds, ["cell-1"]);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/src/receipt-hook.test.ts
+++ b/src/receipt-hook.test.ts
@@ -46,3 +46,18 @@ test("receipt hook attributes only an accepted recall_write to the matching turn
     rmSync(tmp, { recursive: true, force: true });
   }
 });
+
+test("receipt hook ignores an accepted write from a different session", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "recall-receipt-hook-"));
+  const state = join(tmp, "state.json");
+  try {
+    writeFileSync(state, JSON.stringify({ sessionId: "s1", turnId: "t1", turnStart: "2026-07-12T00:00:00Z", admittedIds: [] }));
+    runReceipt(state, {
+      session_id: "s2", turn_id: "t1", tool_name: "mcp__recall__recall_write",
+      tool_response: { accepted: true, id: "cross-session" },
+    });
+    assert.deepEqual(JSON.parse(readFileSync(state, "utf8")).admittedIds, []);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/src/receipt-hook.ts
+++ b/src/receipt-hook.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S node --disable-warning=ExperimentalWarning
+// PostToolUse half of the agent-integrity gate. It attributes an accepted
+// recall_write result to the exact session/turn marker. Stop verifies these
+// IDs against the routed store; ambient/background writes never count.
+import { readFileSync, writeFileSync } from "node:fs";
+import { stdin, stdout, env } from "node:process";
+
+interface Marker {
+  turnStart?: string;
+  sessionId?: string;
+  turnId?: string;
+  cwd?: string;
+  admittedIds?: string[];
+}
+
+function markerPath(sessionId: string | undefined): string {
+  return env.RECALL_STOP_STATE || (sessionId && env.HOME ? `${env.HOME}/.recall/state/stop/${sessionId}.json` : "");
+}
+
+function acceptedId(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    try { return acceptedId(JSON.parse(value)); } catch { return undefined; }
+  }
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (record.accepted === true && typeof record.id === "string") return record.id;
+  if (record.accepted === true && record.cell && typeof record.cell === "object") {
+    const key = (record.cell as Record<string, unknown>).key;
+    if (typeof key === "string") return key;
+  }
+  if (Array.isArray(record.content)) {
+    for (const item of record.content) {
+      const found = acceptedId(item);
+      if (found) return found;
+    }
+  }
+  if (typeof record.text === "string") return acceptedId(record.text);
+  return undefined;
+}
+
+function main(): void {
+  if (stdin.isTTY) { stdout.write("{}\n"); return; }
+  let input: Record<string, unknown> = {};
+  try { input = JSON.parse(readFileSync(0, "utf8")) as Record<string, unknown>; } catch { /* no receipt */ }
+  const toolName = typeof input.tool_name === "string" ? input.tool_name : "";
+  if (!/(?:^|__)recall_write$/.test(toolName)) { stdout.write("{}\n"); return; }
+  const id = acceptedId(input.tool_response);
+  const sessionId = typeof input.session_id === "string" ? input.session_id : undefined;
+  const turnId = typeof input.turn_id === "string" ? input.turn_id : undefined;
+  const path = markerPath(sessionId);
+  if (!id || !path) { stdout.write("{}\n"); return; }
+  try {
+    const marker = JSON.parse(readFileSync(path, "utf8")) as Marker;
+    if (marker.sessionId && sessionId && marker.sessionId !== sessionId) { stdout.write("{}\n"); return; }
+    if (marker.turnId && turnId && marker.turnId !== turnId) { stdout.write("{}\n"); return; }
+    const admittedIds = [...new Set([...(marker.admittedIds ?? []), id])];
+    writeFileSync(path, JSON.stringify({ ...marker, admittedIds }), { mode: 0o600 });
+  } catch {
+    // Missing/malformed marker fails closed at Stop; never create one here.
+  }
+  stdout.write("{}\n");
+}
+
+main();

--- a/src/stop-hook.test.ts
+++ b/src/stop-hook.test.ts
@@ -246,6 +246,64 @@ test("exact no-write footer releases and persists a no-write closure", () => {
   }
 });
 
+test("a non-exact no-write footer does not release the turn", () => {
+  const tmp = tempDir();
+  try {
+    const dbPath = join(tmp, "recall.sqlite3");
+    new SqliteStore(dbPath).close();
+    const statePath = join(tmp, "state.json");
+    writeFileSync(statePath, JSON.stringify({ turnStart: new Date().toISOString(), turnId: "turn-fab" }));
+    const result = spawnSync(
+      process.execPath,
+      ["--disable-warning=ExperimentalWarning", "--import", "tsx", join(__dirname, "stop-hook.ts")],
+      {
+        input: JSON.stringify({
+          session_id: "sess-fab", turn_id: "turn-fab",
+          last_assistant_message: "Work complete.\n\n[Recall no-write: all done]",
+        }),
+        encoding: "utf8",
+        env: { ...process.env, RECALL_DB: dbPath, RECALL_STOP_STATE: statePath },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).decision, "block");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("a verified write from another turn cannot close this turn", () => {
+  const tmp = tempDir();
+  try {
+    const dbPath = join(tmp, "recall.sqlite3");
+    const store = new SqliteStore(dbPath);
+    const cell = buildCell(
+      { kind: "obs", title: "Turn A write", body: "written during turn-a", confidence: 0.9, topics: ["gate"] },
+      { key: "dddddddd-3333-3333-3333-333333333333" },
+    );
+    store.put(cell);
+    store.close();
+    const statePath = join(tmp, "state.json");
+    writeFileSync(statePath, JSON.stringify({
+      turnStart: "2000-01-01T00:00:00.000Z", turnId: "turn-a",
+      admittedIds: [cell.key],
+    }));
+    const result = spawnSync(
+      process.execPath,
+      ["--disable-warning=ExperimentalWarning", "--import", "tsx", join(__dirname, "stop-hook.ts")],
+      {
+        input: JSON.stringify({ session_id: "sess-cross-turn", turn_id: "turn-b" }),
+        encoding: "utf8",
+        env: { ...process.env, RECALL_DB: dbPath, RECALL_STOP_STATE: statePath },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).decision, "block");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("no-write footer cannot bypass a missing turn marker", () => {
   const tmp = tempDir();
   try {

--- a/src/stop-hook.test.ts
+++ b/src/stop-hook.test.ts
@@ -1,13 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { DatabaseSync } from "node:sqlite";
 import { SqliteStore } from "./store.js";
 import { buildCell } from "./build.js";
+import { registerProject, registryDbPath } from "./routing.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -57,7 +58,10 @@ function runStopHook(opts: { dbPath: string; stateDir: string; sessionId?: strin
   const sessionId = opts.sessionId ?? "sess-1";
   const statePath = join(opts.stateDir, `${sessionId}.json`);
   mkdirSync(opts.stateDir, { recursive: true });
-  writeFileSync(statePath, JSON.stringify({ turnStart: "2000-01-01T00:00:00.000Z" }));
+  writeFileSync(statePath, JSON.stringify({
+    turnStart: "2000-01-01T00:00:00.000Z",
+    admittedIds: ["aaaaaaaa-3333-3333-3333-333333333333"],
+  }));
 
   const result = spawnSync(
     process.execPath,
@@ -142,7 +146,10 @@ test("with RECALL_HOME set and no RECALL_DB the stop hook resolves the store und
     const stateDir = join(tmp, "state");
     mkdirSync(stateDir, { recursive: true });
     const statePath = join(stateDir, "sess-rhome.json");
-    writeFileSync(statePath, JSON.stringify({ turnStart: "2000-01-01T00:00:00.000Z" }));
+    writeFileSync(statePath, JSON.stringify({
+      turnStart: "2000-01-01T00:00:00.000Z",
+      admittedIds: ["aaaaaaaa-3333-3333-3333-333333333333"],
+    }));
 
     const env: NodeJS.ProcessEnv = {
       ...process.env,
@@ -166,6 +173,99 @@ test("with RECALL_HOME set and no RECALL_DB the stop hook resolves the store und
       after.close();
     }
     assert.equal(existsSync(join(fakeHome, ".recall")), false); // nothing written under $HOME
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("stop hook routes from the turn cwd to a registered project and records cell ids", () => {
+  const tmp = tempDir();
+  try {
+    const recallHome = join(tmp, "rhome");
+    const projectRoot = join(tmp, "project");
+    mkdirSync(projectRoot, { recursive: true });
+    const env = { ...process.env, RECALL_HOME: recallHome };
+    const project = registerProject(
+      { root: projectRoot, slug: "gate-project" },
+      "2026-07-11T00:00:00.000Z",
+      registryDbPath(env),
+    );
+    seedEmitWitnessProgram(project.dbPath);
+    const statePath = join(tmp, "state.json");
+    writeFileSync(statePath, JSON.stringify({
+      turnStart: "2000-01-01T00:00:00.000Z", turnId: "turn-1", cwd: projectRoot,
+      admittedIds: ["aaaaaaaa-3333-3333-3333-333333333333"],
+    }));
+    const childEnv: NodeJS.ProcessEnv = { ...env, RECALL_STOP_STATE: statePath };
+    delete childEnv.RECALL_DB;
+    const result = spawnSync(
+      process.execPath,
+      ["--disable-warning=ExperimentalWarning", "--import", "tsx", join(__dirname, "stop-hook.ts")],
+      {
+        input: JSON.stringify({ session_id: "sess-project", turn_id: "turn-1", cwd: projectRoot }),
+        encoding: "utf8",
+        env: childEnv,
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {});
+    const receipt = JSON.parse(readFileSync(statePath, "utf8"));
+    assert.equal(receipt.closure.kind, "write");
+    assert.ok(receipt.closure.cellIds.includes("aaaaaaaa-3333-3333-3333-333333333333"));
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("exact no-write footer releases and persists a no-write closure", () => {
+  const tmp = tempDir();
+  try {
+    const dbPath = join(tmp, "recall.sqlite3");
+    new SqliteStore(dbPath).close();
+    const statePath = join(tmp, "state.json");
+    writeFileSync(statePath, JSON.stringify({ turnStart: new Date().toISOString(), turnId: "turn-empty" }));
+    const result = spawnSync(
+      process.execPath,
+      ["--disable-warning=ExperimentalWarning", "--import", "tsx", join(__dirname, "stop-hook.ts")],
+      {
+        input: JSON.stringify({
+          session_id: "sess-empty", turn_id: "turn-empty",
+          last_assistant_message: `Acknowledged.\n\n[Recall no-write: no durable outcome]`,
+        }),
+        encoding: "utf8",
+        env: { ...process.env, RECALL_DB: dbPath, RECALL_STOP_STATE: statePath },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {});
+    const receipt = JSON.parse(readFileSync(statePath, "utf8"));
+    assert.equal(receipt.closure.kind, "no-write");
+    assert.deepEqual(receipt.closure.cellIds, []);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("no-write footer cannot bypass a missing turn marker", () => {
+  const tmp = tempDir();
+  try {
+    const dbPath = join(tmp, "recall.sqlite3");
+    new SqliteStore(dbPath).close();
+    const statePath = join(tmp, "missing-state.json");
+    const result = spawnSync(
+      process.execPath,
+      ["--disable-warning=ExperimentalWarning", "--import", "tsx", join(__dirname, "stop-hook.ts")],
+      {
+        input: JSON.stringify({
+          session_id: "sess-no-marker", turn_id: "turn-no-marker",
+          last_assistant_message: "[Recall no-write: no durable outcome]",
+        }),
+        encoding: "utf8",
+        env: { ...process.env, RECALL_DB: dbPath, RECALL_STOP_STATE: statePath },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).decision, "block");
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
@@ -206,7 +306,10 @@ test("stop endcap still swallows store errors and releases the turn", () => {
     const stateDir = join(tmp, "state");
     mkdirSync(stateDir, { recursive: true });
     const statePath = join(stateDir, "sess-err.json");
-    writeFileSync(statePath, JSON.stringify({ turnStart: "2000-01-01T00:00:00.000Z" }));
+    writeFileSync(statePath, JSON.stringify({
+      turnStart: "2000-01-01T00:00:00.000Z",
+      admittedIds: ["aaaaaaaa-3333-3333-3333-333333333333"],
+    }));
 
     const result = spawnSync(
       process.execPath,

--- a/src/stop-hook.ts
+++ b/src/stop-hook.ts
@@ -7,33 +7,46 @@
 //
 // Marker: $RECALL_STOP_STATE, else $HOME/.recall/state/stop/<session_id>.json,
 // shaped { "turnStart": ISO }. No marker means fail-closed (hold).
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { stdin, stdout, env } from "node:process";
-import { stopHookResponse } from "./stop.js";
+import { NO_WRITE_RECEIPT, stopHookResponse } from "./stop.js";
 import { SqliteStore } from "./store.js";
 import { runOperatorCycle } from "./operator.js";
-import { homeDbPath } from "./routing.js";
+import { resolveDbForCwd } from "./routing.js";
+
+interface TurnMarker {
+  turnStart?: string;
+  sessionId?: string;
+  turnId?: string;
+  cwd?: string;
+  admittedIds?: string[];
+  closure?: { kind: "write" | "no-write"; cellIds: string[]; closedAt: string };
+}
 
 function markerPath(sessionId: string | undefined): string {
   return env.RECALL_STOP_STATE || (sessionId && env.HOME ? `${env.HOME}/.recall/state/stop/${sessionId}.json` : "");
 }
-function turnStart(sessionId: string | undefined): string | undefined {
+function readMarker(sessionId: string | undefined): TurnMarker {
   const path = markerPath(sessionId);
-  if (!path) return undefined;
+  if (!path) return {};
   try {
-    return (JSON.parse(readFileSync(path, "utf8")) as { turnStart?: string }).turnStart;
+    return JSON.parse(readFileSync(path, "utf8")) as TurnMarker;
   } catch {
-    return undefined;
+    return {};
   }
 }
-function dbPath(): string {
-  // RECALL_DB overrides; otherwise the RECALL_HOME-derived home store, which
-  // itself falls back to the HOME-derived ~/.recall/db/home.sqlite3.
-  return env.RECALL_DB ?? homeDbPath(env);
+function dbPath(cwd: string | undefined): string {
+  return resolveDbForCwd(cwd || process.cwd(), env);
 }
-function wroteSince(store: SqliteStore, since: string | undefined): boolean {
-  if (!since) return false; // no turn-start marker => fail closed (hold)
-  return store.active().some((c) => c.createdAt >= since);
+function verifiedTurnWrites(store: SqliteStore, marker: TurnMarker): string[] {
+  const since = marker.turnStart;
+  if (!since) return [];
+  return [...new Set(marker.admittedIds ?? [])]
+    .filter((id) => {
+      const cell = store.get(id);
+      return cell !== undefined && cell.createdAt >= since;
+    })
+    .sort();
 }
 
 function main(): void {
@@ -52,13 +65,21 @@ function main(): void {
     return;
   }
   let sessionId: string | undefined;
+  let turnId: string | undefined;
+  let cwd: string | undefined;
+  let lastAssistantMessage = "";
   try {
-    sessionId = (JSON.parse(raw) as { session_id?: string }).session_id;
+    const input = JSON.parse(raw) as { session_id?: string; turn_id?: string; cwd?: string; last_assistant_message?: string };
+    sessionId = input.session_id;
+    turnId = input.turn_id;
+    cwd = input.cwd;
+    lastAssistantMessage = input.last_assistant_message ?? "";
   } catch {
     // malformed stdin
   }
 
-  const path = dbPath();
+  const marker = readMarker(sessionId);
+  const path = dbPath(cwd ?? marker.cwd);
   if (!path) {
     stdout.write("{}\n"); // no db: cannot gate, do not block
     return;
@@ -72,8 +93,28 @@ function main(): void {
     return;
   }
   try {
-    const response = stopHookResponse({ wroteThisTurn: wroteSince(store, turnStart(sessionId)) });
+    const markerMatchesTurn = !marker.turnId || !turnId || marker.turnId === turnId;
+    const cellIds = markerMatchesTurn ? verifiedTurnWrites(store, marker) : [];
+    const noWriteReceipt = markerMatchesTurn
+      && typeof marker.turnStart === "string"
+      && lastAssistantMessage.trimEnd().endsWith(NO_WRITE_RECEIPT);
+    const response = stopHookResponse({ wroteThisTurn: cellIds.length > 0, noWriteReceipt });
     if (!response.decision) {
+      const statePath = markerPath(sessionId);
+      if (statePath) {
+        try {
+          writeFileSync(statePath, JSON.stringify({
+            ...marker,
+            closure: {
+              kind: cellIds.length > 0 ? "write" : "no-write",
+              cellIds,
+              closedAt: new Date().toISOString(),
+            },
+          }));
+        } catch {
+          // receipt persistence is best effort; admission itself already succeeded
+        }
+      }
       // released: run the endcap operator cycle so the graph is current for the
       // next turn. Best-effort: a tick error must never block release.
       // derive:true admits standing-program witnesses here too. This is

--- a/src/stop.test.ts
+++ b/src/stop.test.ts
@@ -25,6 +25,10 @@ test("stopHookResponse releases with an empty object when something was written"
   assert.deepEqual(stopHookResponse({ wroteThisTurn: true }), {});
 });
 
+test("stop releases on an explicit no-write receipt without claiming a write", () => {
+  assert.deepEqual(stopHookResponse({ wroteThisTurn: false, noWriteReceipt: true }), {});
+});
+
 test("stopHookResponse blocks with the template appended when nothing was written", () => {
   const r = stopHookResponse({ wroteThisTurn: false });
   assert.equal(r.decision, "block");

--- a/src/stop.ts
+++ b/src/stop.ts
@@ -9,6 +9,7 @@ import { WRITE_TEMPLATE } from "./template.js";
 
 export interface StopState {
   wroteThisTurn: boolean; // did any durable cell get created this turn
+  noWriteReceipt?: boolean; // explicit attestation that no durable outcome exists
 }
 
 export interface StopDecision {
@@ -22,15 +23,19 @@ export function renderWriteTemplate(): Record<string, string> {
 }
 
 export function stopDecision(state: StopState): StopDecision {
-  if (state.wroteThisTurn) {
+  if (state.wroteThisTurn || state.noWriteReceipt) {
     return { release: true, reason: "" };
   }
   const reason = [
     "[Recall Stop gate] The turn cannot end until a durable write-back is admitted this turn.",
-    "Write what you learned. Fill every template field with a real value; a field left as its description is rejected. State contradictions and concerns explicitly; if none, say none and why.",
+    "Write what you learned. Fill every template field with a real value (use null only when genuinely not applicable); a missing field or a field left as its description is rejected.",
+    "At least one honest, resolvable edge is required. Never invent memory or an edge to satisfy this gate.",
+    "If this turn produced no durable outcome, end with exactly: [Recall no-write: no durable outcome]",
   ].join("\n");
   return { release: false, reason, template: renderWriteTemplate() };
 }
+
+export const NO_WRITE_RECEIPT = "[Recall no-write: no durable outcome]";
 
 // Map a stop decision to the Claude Code Stop-hook output. Release is `{}` (the
 // turn ends). Hold is `{decision:"block", reason}` with the template appended so

--- a/src/template.ts
+++ b/src/template.ts
@@ -54,10 +54,27 @@ void _templateCoversProposal;
 // A field whose submitted value still equals its template description was never
 // filled. Returns one issue per such field; admission rejects on any, and the
 // Stop hook holds the turn until none remain.
-export function templateIssues(proposal: WriteProposal): ValidationIssue[] {
+export interface TemplateIssueOptions {
+  /** Require an explicit submitted value for every authorable primitive. */
+  requireComplete?: boolean;
+  /** Require at least one honest graph connection. */
+  requireEdge?: boolean;
+}
+
+export function templateIssues(
+  proposal: WriteProposal,
+  opts: TemplateIssueOptions = {},
+): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const p = proposal as unknown as Record<string, unknown>;
   for (const field of Object.keys(WRITE_TEMPLATE) as WriteTemplateField[]) {
+    if (opts.requireComplete && !Object.prototype.hasOwnProperty.call(p, field)) {
+      issues.push({
+        path: field,
+        message: `${field} is missing; submit an explicit value or null when it is not applicable`,
+      });
+      continue;
+    }
     const value = p[field];
     if (typeof value === "string" && value.trim() === WRITE_TEMPLATE[field].trim()) {
       issues.push({
@@ -65,6 +82,12 @@ export function templateIssues(proposal: WriteProposal): ValidationIssue[] {
         message: `${field} still holds its template instruction; replace it with a real value`,
       });
     }
+  }
+  if (opts.requireEdge && (!Array.isArray(p.edges) || p.edges.length === 0)) {
+    issues.push({
+      path: "edges",
+      message: "at least one honest, resolvable edge is required; use a no-write receipt instead of fabricating one",
+    });
   }
   return issues;
 }


### PR DESCRIPTION
Brings the agent-integrity write gate trial to main.

- Codex parity: recall codex sync --write-gate registers the MCP server with the admission gate's complete-envelope mode. Every authorable primitive must be present and differ from its instructional template; every durable write must carry at least one honest resolvable edge. Explicit nulls mark genuinely inapplicable optional primitives and are normalized before ordinary v5 validation.
- Turn closure: prompt markers now carry session, turn, cwd, and start time. A new PostToolUse receipt hook attributes only accepted recall_write IDs to the matching turn; rejected, stale, Bash-spoofed, daemon, and ambient writes cannot satisfy the obligation. Stop verifies those IDs in the registered project graph instead of silently checking home, records them in its closure receipt, and accepts the exact auditable no-write footer so enforcement never rewards fabricated memory.

Testing: full suite green locally (838 pass, 0 fail) before and after merging main into the branch. The gate itself previously passed adversarial live acceptance in a live session.